### PR TITLE
Fixed parsing int and float

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,35 @@
+name: CMake
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+      

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,18 @@ add_library(models
         model/Calendars.cpp
         model/Currtypes.cpp
         model/Udfs.cpp
+        model/UDFTypes.cpp
         model/Wbss.cpp
         model/RCatTypes.cpp
         model/RCatValues.cpp
+        model/Roles.cpp
         model/RoleRates.cpp
         model/TaskRsrcs.cpp
         model/Obss.cpp
         model/NonWorks.cpp
-        model/Fintmpls.cpp)
+        model/Fintmpls.cpp
+        
+        )
 
 add_library(classes
         model/classes/Account.cpp
@@ -26,16 +30,21 @@ add_library(classes
         model/classes/Calendar.cpp
         model/classes/Currtype.cpp
         model/classes/Udf.cpp
+        model/classes/UDFType.cpp
         model/classes/Wbs.cpp
         model/classes/RCatType.cpp
         model/classes/RCatValue.cpp
+        model/classes/Role.cpp
         model/classes/RoleRate.cpp
         model/classes/TaskRsrc.cpp
         model/classes/Obs.cpp
         model/classes/NonWork.cpp
         model/classes/Fintmpl.cpp)
 
-add_library(xerParser Reader.cpp Writer.cpp Date/Date.cpp)
+add_library(date Date/Date.cpp)
+target_link_libraries(classes  date)
+
+add_library(xerParser Reader.cpp Writer.cpp )
 
 add_executable(main main.cpp)
-target_link_libraries(main xerParser models classes)
+target_link_libraries(main xerParser models classes )

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -1,7 +1,7 @@
 #include <cassert>
 #include "Reader.h"
 
-#define MAX_HEADER_LEN 255 //TODO: Count the real maximum (255 is not the real value)
+#define MAX_HEADER_LEN 255 // TODO: Count the real maximum (255 is not the real value)
 
 void Reader::split(std::string *strings, const std::string &str)
 {
@@ -22,76 +22,172 @@ void Reader::split(std::string *strings, const std::string &str)
 	}
 }
 
-int Reader::parse(const std::string& filename) {
-	std::ifstream fin (filename);
-	if(fin.is_open()){
+int Reader::parse(const std::string &filename)
+{
+	std::ifstream fin(filename);
+	if (fin.is_open())
+	{
 		std::string line;
 		std::string current_table;
 		std::string current_header[MAX_HEADER_LEN];
 		std::string current_record[MAX_HEADER_LEN];
 
-		while (getline(fin, line)){
+		while (getline(fin, line))
+		{
 			// Split line into tab-separated parts
 			std::string parts[MAX_HEADER_LEN] = {""};
 			split(parts, line);
 			// check if line starts with %T then it's a table
-			if (parts[0] == "%T"){
+			if (parts[0] == "%T")
+			{
 				current_table = parts[1];
 			}
 			// check if line starts with %F then it's a header
-			else if (parts[0] == "%F"){
-				for (uint i = 0; i < MAX_HEADER_LEN; i++){
-					if(parts[i+1].empty()) break;
-					current_header[i] = parts[i+1];
+			else if (parts[0] == "%F")
+			{
+				for (uint i = 0; i < MAX_HEADER_LEN; i++)
+				{
+					if (parts[i + 1].empty())
+						break;
+					current_header[i] = parts[i + 1];
 				}
 			}
-				// check if line starts with %R then it is a record that could be parsed to the class
-				// matching the table name
-			else if (parts[0] == "%R"){
-				for (uint i = 0; i < MAX_HEADER_LEN; i++){
-					if(current_header[i].empty()) break;
-					current_record[i] = parts[i+1];
+			// check if line starts with %R then it is a record that could be parsed to the class
+			// matching the table name
+			else if (parts[0] == "%R")
+			{
+				for (uint i = 0; i < MAX_HEADER_LEN; i++)
+				{
+					if (current_header[i].empty())
+						break;
+					current_record[i] = parts[i + 1];
 				}
 				add(current_table, current_header, current_record);
 			}
 		}
 		fin.close();
 	}
-	else{
+	else
+	{
 		std::cout << "Unable to open" << std::endl;
 	}
-  return 0;
+	return 0;
 }
 
-void Reader::add(const std::string& table, const std::string *header, const std::string *record){
+void Reader::add(const std::string &table, const std::string *header, const std::string *record)
+{
 	assert(not(table.empty() || header == nullptr || record == nullptr));
 
-	if (table == "ACCOUNT"){ accounts.add(Account(header, record)); }
-	else if (table == "ACTVCODE"){ actvcodes.add(Actvcode(header, record)); }
-	else if (table == "ACTVTYPE"){ actvtypes.add(Actvtype(header, record)); }
-	else if (table == "CALENDAR"){ calendars.add(Calendar(header, record)); }
-	else if (table == "PROJWBS"){ wbss.add(Wbs(header, record)); }
-	else if (table == "UDFVALUE"){ udfs.add(Udf(header, record)); }
-	else if (table == "UDFTYPE"){ udftypes.add(UDFType(header, record)); }
-	else if (table == "ROLE"){ roles.add( Role(header, record, this) ); }
-	else if (table == "CURRTYPE"){ currencies.add(Currtype(header, record)); }
-	else if (table == "RCATTYPE"){ rCatTypes.add(RCatType(header, record)); }
-	else if (table == "RCATVAL"){ rCatValues.add(RCatValue(header, record)); }
-	else if (table == "ROLERATE"){ roleRates.add(RoleRate(header, record)); }
-	else if (table == "TASKRSRC"){ taskRsrcs.add(TaskRsrc(header, record)); }
-	else if (table == "OBS"){ obss.add(Obs(header, record)); }
-	else if (table == "NONWORK"){ nonWorks.add(NonWork(header, record)); }
-	else if (table == "FINTMPL"){ fintmpls.add(Fintmpl(header, record)); }
-	else if (table == "PCATTYPE"){ pcattypes.add(Pcattype(header, record)); }
-	else if (table == "PCATVAL"){ pcatvals.add(Pcatval(header, record)); }
-	else if (table == "TASKPRED"){ taskpreds.add(Taskpred(header, record)); }
-	else if (table == "PROJPCAT"){ projpcats.add(Projpcat(header, record)); }
-	else if (table == "PROJECT"){ projects.add(Project(header, record)); }
-	else if (table == "RSRC"){ rsrcs.add(Rsrc(header, record)); }
-	else if (table == "RSRCRCAT"){ rsrcrcats.add(Rsrcrcat(header, record)); }
-	else if (table == "RSRCCURVDATA"){ rsrccurvdatas.add(Rsrccurvdata(header, record)); }
-	else if (table == "RSRCRATE"){ rsrcrates.add(Rsrcrate(header, record)); }
-	else if (table == "SCHEDOPTION"){ schedoptions.add(Schedoption(header, record)); }
-	else if (table == "TASKACTV"){ taskactvs.add(Taskactv(header, record)); }
-	else if (table == "TASKPROC"){ taskprocs.add(Taskproc(header, record)); }
+	if (table == "ACCOUNT")
+	{
+		accounts.add(Account(header, record));
+	}
+	else if (table == "ACTVCODE")
+	{
+		actvcodes.add(Actvcode(header, record));
+	}
+	else if (table == "ACTVTYPE")
+	{
+		actvtypes.add(Actvtype(header, record));
+	}
+	else if (table == "CALENDAR")
+	{
+		calendars.add(Calendar(header, record));
+	}
+	else if (table == "PROJWBS")
+	{
+		wbss.add(Wbs(header, record));
+	}
+	else if (table == "UDFVALUE")
+	{
+		udfs.add(Udf(header, record));
+	}
+	else if (table == "UDFTYPE")
+	{
+		udftypes.add(UDFType(header, record));
+	}
+	else if (table == "ROLE")
+	{
+		roles.add(Role(header, record, this));
+	}
+	else if (table == "CURRTYPE")
+	{
+		currencies.add(Currtype(header, record));
+	}
+	else if (table == "RCATTYPE")
+	{
+		rCatTypes.add(RCatType(header, record));
+	}
+	else if (table == "RCATVAL")
+	{
+		rCatValues.add(RCatValue(header, record));
+	}
+	else if (table == "ROLERATE")
+	{
+		roleRates.add(RoleRate(header, record));
+	}
+	else if (table == "TASKRSRC")
+	{
+		taskRsrcs.add(TaskRsrc(header, record));
+	}
+	else if (table == "OBS")
+	{
+		obss.add(Obs(header, record));
+	}
+	else if (table == "NONWORK")
+	{
+		nonWorks.add(NonWork(header, record));
+	}
+	else if (table == "FINTMPL")
+	{
+		fintmpls.add(Fintmpl(header, record));
+	}
+	else if (table == "PCATTYPE")
+	{
+		pcattypes.add(Pcattype(header, record));
+	}
+	else if (table == "PCATVAL")
+	{
+		pcatvals.add(Pcatval(header, record));
+	}
+	else if (table == "TASKPRED")
+	{
+		taskpreds.add(Taskpred(header, record));
+	}
+	else if (table == "PROJPCAT")
+	{
+		projpcats.add(Projpcat(header, record));
+	}
+	else if (table == "PROJECT")
+	{
+		projects.add(Project(header, record));
+	}
+	else if (table == "RSRC")
+	{
+		rsrcs.add(Rsrc(header, record, this));
+	}
+	else if (table == "RSRCRCAT")
+	{
+		rsrcrcats.add(Rsrcrcat(header, record));
+	}
+	else if (table == "RSRCCURVDATA")
+	{
+		rsrccurvdatas.add(Rsrccurvdata(header, record));
+	}
+	else if (table == "RSRCRATE")
+	{
+		rsrcrates.add(Rsrcrate(header, record));
+	}
+	else if (table == "SCHEDOPTION")
+	{
+		schedoptions.add(Schedoption(header, record));
+	}
+	else if (table == "TASKACTV")
+	{
+		taskactvs.add(Taskactv(header, record));
+	}
+	else if (table == "TASKPROC")
+	{
+		taskprocs.add(Taskproc(header, record));
+	}
 }

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -73,7 +73,7 @@ void Reader::add(const std::string& table, const std::string *header, const std:
 	else if (table == "PROJWBS"){ wbss.add(Wbs(header, record)); }
 	else if (table == "UDFVALUE"){ udfs.add(Udf(header, record)); }
 	else if (table == "UDFTYPE"){ udftypes.add(UDFType(header, record)); }
-	else if (table == "ROLE"){ roles.add(Role(header, record)); }
+	else if (table == "ROLE"){ roles.add( Role(header, record, this) ); }
 	else if (table == "CURRTYPE"){ currencies.add(Currtype(header, record)); }
 	else if (table == "RCATTYPE"){ rCatTypes.add(RCatType(header, record)); }
 	else if (table == "RCATVAL"){ rCatValues.add(RCatValue(header, record)); }

--- a/main.cpp
+++ b/main.cpp
@@ -27,4 +27,13 @@ int main(){
     for(Currtype curr: reader.currencies.getAll()){
         cout << "Currencies "<<curr.get_tsv() << endl;
     }
+
+    cout << "***************** Roles and RoleRates **********************" << endl;
+
+    for (Role role: reader.roles.getAll()){
+        std::vector<RoleRate> rRates = role.getRoleRate();
+        for(RoleRate rr: rRates){
+            cout << to_string(rr.role_rate_id) << endl;
+        }
+    }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -3,14 +3,15 @@
 
 using namespace std;
 
-int main(){
+int main()
+{
     Reader reader;
-    
-    reader.parse("/home/hassan/programming/xerParser/sample.xer");
 
-    for (Udf udf :reader.udfs.getByProject(368) )
+    reader.parse("/home/hassan/programming/xerParser/wk2.xer");
+
+    for (Udf udf : reader.udfs.getByProject(368))
     {
-        cout<<udf.get_tsv() <<std::endl;
+        cout << udf.get_tsv() << std::endl;
     }
 
     cout << "*********** TEST WBS **********************" << endl;
@@ -19,21 +20,32 @@ int main(){
         cout << wbs.get_tsv() << endl;
     }
     cout << "**************** CALENDAR *************************" << endl;
-    for(Calendar cal: reader.calendars.getAll()){
-        cout << cal.get_tsv()<<endl;
+    for (Calendar cal : reader.calendars.getAll())
+    {
+        cout << cal.get_tsv() << endl;
     }
 
     cout << "***************** CURRENCIES **********************" << endl;
-    for(Currtype curr: reader.currencies.getAll()){
-        cout << "Currencies "<<curr.get_tsv() << endl;
+    for (Currtype curr : reader.currencies.getAll())
+    {
+        cout << "Currencies " << curr.get_tsv() << endl;
     }
 
-    cout << "***************** Roles and RoleRates **********************" << endl;
+    cout << "***************** Resrouece and Resource Rates **********************" << endl;
 
-    for (Role role: reader.roles.getAll()){
-        std::vector<RoleRate> rRates = role.getRoleRate();
-        for(RoleRate rr: rRates){
-            cout << to_string(rr.role_rate_id) << endl;
+    for (Rsrc rsrc : reader.rsrcs.getAll())
+    {
+        std::vector<Rsrcrate> rRates = reader.rsrcrates.getByRsrcId(rsrc.rsrc_id);
+        std::vector<TaskRsrc> trs = reader.taskRsrcs.getByRsrcId(rsrc.rsrc_id);
+        for (Rsrcrate rr : rRates)
+        {
+            cout << to_string(rr.rsrc_id) << endl;
+        }
+
+        cout << "RSRC_ID => Task_ID" << endl;
+        for (TaskRsrc tr : trs)
+        {
+            cout << to_string(tr.rsrc_id) << " => " << to_string(tr.task_id) << endl;
         }
     }
 }

--- a/model/Calendars.cpp
+++ b/model/Calendars.cpp
@@ -26,7 +26,7 @@ std::string Calendars::get_tsv() const{
 	tsv.append("%F\tclndr_id\tday_hr_cnt\tweek_hr_cnt\tmonth_hr_cnt\tyear_hr_cnt\tbase_clndr_id"
 						 "\tclndr_data\tclndr_name\tclndr_type\tdefault_flag\tlast_chng_date\tproj_id\n");
 	for(auto & calendar : calendars){
-		tsv.append(calendar.get_tsv());
+		tsv.append(calendar.tsv);
 	}
 	return tsv;
 }

--- a/model/Fintmpls.cpp
+++ b/model/Fintmpls.cpp
@@ -18,7 +18,7 @@ Fintmpl Fintmpls::findById(int id){
 }
 
 std::vector<Fintmpl> Fintmpls::getAll(){
-	return fintmpls
+	return fintmpls;
 }
 
 std::string Fintmpls::get_tsv() const{

--- a/model/Fintmpls.cpp
+++ b/model/Fintmpls.cpp
@@ -1,0 +1,24 @@
+#include "Fintmpls"
+
+void Fintmpls::add(const Fintmpl & fintmpl){
+    fintmpls.embrace_back(fintmpl);
+}
+
+Fintmpl findById(int id){
+    for(Fintmpl ft: fintmpls){
+        if(ft.fintmpl_id == id){
+            return ft;
+        }
+    }
+    printf("Could not find Financial Tmplate with given id");
+    exit(EXIT_FAILURE);
+}
+
+std::string get_tsv(){
+    std::string tsv;
+    tsv.append("%T\tFINTMPL\n");
+    tsv.append("%F\tfintmpl_id\tfintmpl_name\tdefault_flag\n");
+    for(auto ft: fintmpls){
+        tsv.append(ft.get_tsv())
+    }
+}

--- a/model/Fintmpls.h
+++ b/model/Fintmpls.h
@@ -1,0 +1,20 @@
+#ifndef XER_FINTMPLS_H_
+#define XER_FINTMPLS_H_
+
+#include <string>
+#include <vector>
+#include "classes/Fintmpl.h"
+
+class Fintmpls{
+
+    public:
+        void add(const Fintmpl fintmpl);
+        Fintmpl findById(int id);
+        std::string get_tsv();
+
+    private:
+        std::vector<Fintmpl> fintmpls;
+};
+
+#endif // !XER_FINTMPLS_H_#define XER_FINTMPLS_H_
+

--- a/model/RoleRates.cpp
+++ b/model/RoleRates.cpp
@@ -14,6 +14,8 @@ RoleRate RoleRates::findById(int id){
             return rr;
         }
     }
+    printf("Could Not Find Role Rate");
+    exit(EXIT_FAILURE);
 }
 
 RoleRate RoleRates::findByRole(int id){
@@ -22,6 +24,8 @@ RoleRate RoleRates::findByRole(int id){
             return rr;
         }
     }
+    printf("Could not find Role Rate");
+    exit(EXIT_FAILURE);
 }
 
 std::string RoleRates::get_tsv() const{

--- a/model/Roles.h
+++ b/model/Roles.h
@@ -5,6 +5,8 @@
 #include<string>
 #include "classes/Role.h"
 
+class Reader;
+
 class Roles{
     public:
         void add(const Role &role);

--- a/model/Rsrcrates.cpp
+++ b/model/Rsrcrates.cpp
@@ -4,11 +4,14 @@
 
 #include "Rsrcrates.h"
 
-void Rsrcrates::add(const Rsrcrate& rsrcrate){ rsrcrates.emplace_back(rsrcrate); }
+void Rsrcrates::add(const Rsrcrate &rsrcrate) { rsrcrates.emplace_back(rsrcrate); }
 
-Rsrcrate Rsrcrates::findById(int id){
-	for(auto & rsrcrate : rsrcrates){
-		if(rsrcrate.rsrc_id == id){
+Rsrcrate Rsrcrates::findById(int id)
+{
+	for (auto &rsrcrate : rsrcrates)
+	{
+		if (rsrcrate.rsrc_id == id)
+		{
 			return rsrcrate;
 		}
 	}
@@ -16,17 +19,33 @@ Rsrcrate Rsrcrates::findById(int id){
 	exit(EXIT_FAILURE);
 }
 
-std::vector<Rsrcrate> Rsrcrates::getAll(){
+std::vector<Rsrcrate> Rsrcrates::getAll()
+{
 	return rsrcrates;
 }
 
-std::string Rsrcrates::get_tsv() const{
+std::string Rsrcrates::get_tsv() const
+{
 	std::string tsv;
 	tsv.append("%T\tRSRCRATE\n");
 	tsv.append("%F\trsrc_rate\trsrc_id\tmax_qty_per_hr\tcost_per_qty\tcost_per_qty2\t"
-						 "cost_per_qty3\tcost_per_qty4\tcost_per_qty5\tshift_period_id\tstart_date\n");
-	for(auto & rsrcrate : rsrcrates){
+			   "cost_per_qty3\tcost_per_qty4\tcost_per_qty5\tshift_period_id\tstart_date\n");
+	for (auto &rsrcrate : rsrcrates)
+	{
 		tsv.append(rsrcrate.tsv);
 	}
 	return tsv;
+}
+
+std::vector<Rsrcrate> Rsrcrates::getByRsrcId(int id)
+{
+	std::vector<Rsrcrate> toReturn;
+	for (Rsrcrate rr : rsrcrates)
+	{
+		if (rr.rsrc_id == id)
+		{
+			toReturn.emplace_back(rr);
+		}
+	}
+	return toReturn;
 }

--- a/model/Rsrcrates.h
+++ b/model/Rsrcrates.h
@@ -9,20 +9,19 @@
 
 #include "classes/Rsrcrate.h"
 
-class Rsrcrates{
+class Rsrcrates
+{
 public:
-		void add(const Rsrcrate& rsrcrate);
+	void add(const Rsrcrate &rsrcrate);
 
-		Rsrcrate findById(int id);
-		std::vector<Rsrcrate> getAll();
+	Rsrcrate findById(int id);
+	std::vector<Rsrcrate> getAll();
 
-
-		std::string get_tsv() const;
-
+	std::string get_tsv() const;
+	std::vector<Rsrcrate> getByRsrcId(int id);
 
 private:
-		std::vector<Rsrcrate> rsrcrates;
+	std::vector<Rsrcrate> rsrcrates;
 };
 
-
-#endif //XERPARSER_RSRCRATES_H
+#endif // XERPARSER_RSRCRATES_H

--- a/model/TaskRsrcs.cpp
+++ b/model/TaskRsrcs.cpp
@@ -4,11 +4,14 @@
 
 #include "TaskRsrcs.h"
 
-void TaskRsrcs::add(const TaskRsrc& taskRsrc){ taskRsrcs.emplace_back(taskRsrc); }
+void TaskRsrcs::add(const TaskRsrc &taskRsrc) { taskRsrcs.emplace_back(taskRsrc); }
 
-TaskRsrc TaskRsrcs::findById(int id){
-	for(auto & taskRsrc : taskRsrcs){
-		if(taskRsrc.taskrsrc_id == id){
+TaskRsrc TaskRsrcs::findById(int id)
+{
+	for (auto &taskRsrc : taskRsrcs)
+	{
+		if (taskRsrc.taskrsrc_id == id)
+		{
 			return taskRsrc;
 		}
 	}
@@ -16,25 +19,41 @@ TaskRsrc TaskRsrcs::findById(int id){
 	exit(EXIT_FAILURE);
 }
 
-std::vector<TaskRsrc> TaskRsrcs::getAll(){
+std::vector<TaskRsrc> TaskRsrcs::getAll()
+{
 	return taskRsrcs;
 }
 
-std::string TaskRsrcs::get_tsv() const{
+std::string TaskRsrcs::get_tsv() const
+{
 	std::string tsv;
 	tsv.append("%T\tTASKRSRC\n");
 	tsv.append("%F\ttaskrsrc_id\ttask_id\tproj_id\tcost_qty_link_flag\trole_id\tacct_id\t"
-						 "rsrc_id\tpobs_id\tskill_level\tremain_qty\ttarget_qty\tremain_qty_per_hour\t"
-						 "target_lag_drtn_hr_cnt\ttarget_qty_per_hour\tact_ot_qty\tact_reg_qty\t"
-						 "relag_drtn_hr_cnt\tot_factor\tcost_per_qty\ttarget_cost\tact_reg_cost\t"
-						 "act_ot_cost\tremain_cost\tact_start_date\tact_end_date\trestart_date\t"
-						 "reend_date\ttarget_start_date\ttarget_end_date\trem_late_start_date\t"
-						 "rem_late_end_date\trollup_dates_flag\ttarget_crv\tremain_crv\tactual_crv\t"
-						 "ts_pend_act_end_flag\tguid\trate_type\tact_this_per_cost\tact_this_per_qty\t"
-						 "curv_id\trsrc_type\tcost_per_qty_source_type\tcreate_user\tcreate_date\t"
-						 "cbs_id\thas_rsrchours\ttaskrsrc_sum_id\n");
-	for(auto & taskRsrc : taskRsrcs){
+			   "rsrc_id\tpobs_id\tskill_level\tremain_qty\ttarget_qty\tremain_qty_per_hour\t"
+			   "target_lag_drtn_hr_cnt\ttarget_qty_per_hour\tact_ot_qty\tact_reg_qty\t"
+			   "relag_drtn_hr_cnt\tot_factor\tcost_per_qty\ttarget_cost\tact_reg_cost\t"
+			   "act_ot_cost\tremain_cost\tact_start_date\tact_end_date\trestart_date\t"
+			   "reend_date\ttarget_start_date\ttarget_end_date\trem_late_start_date\t"
+			   "rem_late_end_date\trollup_dates_flag\ttarget_crv\tremain_crv\tactual_crv\t"
+			   "ts_pend_act_end_flag\tguid\trate_type\tact_this_per_cost\tact_this_per_qty\t"
+			   "curv_id\trsrc_type\tcost_per_qty_source_type\tcreate_user\tcreate_date\t"
+			   "cbs_id\thas_rsrchours\ttaskrsrc_sum_id\n");
+	for (auto &taskRsrc : taskRsrcs)
+	{
 		tsv.append(taskRsrc.tsv);
 	}
 	return tsv;
+}
+
+std::vector<TaskRsrc> TaskRsrcs::getByRsrcId(int id)
+{
+	std::vector<TaskRsrc> toReturn;
+	for (auto tr : taskRsrcs)
+	{
+		if (tr.rsrc_id == id)
+		{
+			toReturn.emplace_back(tr);
+		}
+	}
+	return toReturn;
 }

--- a/model/TaskRsrcs.h
+++ b/model/TaskRsrcs.h
@@ -9,20 +9,19 @@
 
 #include <vector>
 
-class TaskRsrcs{
+class TaskRsrcs
+{
 public:
-		void add(const TaskRsrc& taskRsrc);
+	void add(const TaskRsrc &taskRsrc);
 
-		TaskRsrc findById(int id);
-		std::vector<TaskRsrc> getAll();
+	TaskRsrc findById(int id);
+	std::vector<TaskRsrc> getAll();
+	std::vector<TaskRsrc> getByRsrcId(int id);
 
-
-		std::string get_tsv() const;
-
+	std::string get_tsv() const;
 
 private:
-		std::vector<TaskRsrc> taskRsrcs;
+	std::vector<TaskRsrc> taskRsrcs;
 };
 
-
-#endif //XERPARSER_TASKRSRCS_H
+#endif // XERPARSER_TASKRSRCS_H

--- a/model/classes/Calendar.h
+++ b/model/classes/Calendar.h
@@ -23,10 +23,11 @@ public:
 		std::string proj_id;
 
 		std::string get_tsv();
+		std::string tsv;
 
 		Calendar(const std::string *header, const std::string *params);
 	private:
-		std::string tsv;
+		
 
 };
 

--- a/model/classes/Fintmpl.cpp
+++ b/model/classes/Fintmpl.cpp
@@ -1,0 +1,25 @@
+#include "Fintmpl.h"
+
+
+Fintmpl::Fintmpl(const std::string header, const std::string params){
+    for (int i = 0; i < header->length(); i++){
+        if(header[i].empty()) break;
+        if (header[i] == "fintmpl_id"){
+            if(!params[i].empty()){
+                fintmpl_id = stoi(params[i]);
+            }
+        } else if (header[i] == "fintmpl_name"){
+            fintmpl_name = params[i];
+        } else if (header[i] == default_flag){
+            default_flag = params[i];
+        }
+    }
+}
+
+std::string Fintmpl::get_tsv(){
+    tsv = "";
+    tsv.append(std::to_string(fintmpl_id)).append("\t")
+        .append(fintmpl_name).append("\t")
+        .append(default_flag).append("\n")
+}
+

--- a/model/classes/Fintmpl.cpp
+++ b/model/classes/Fintmpl.cpp
@@ -7,7 +7,11 @@
 Fintmpl::Fintmpl(const std::string *header, const std::string *params){
 	tsv = "";
 	for(uint i = 0; i < header->length(); i++){
-		if(header[i] == "fintmpl_id"){ fintmpl_id = stoi(params[i]); }
+		if(header[i] == "fintmpl_id"){ 
+			if(!params[i].empty()){
+				fintmpl_id = stoi(params[i]); 
+				}
+		}
 		else if(header[i] == "fintmpl_name"){ fintmpl_name = params[i]; }
 		else if(header[i] == "default_flag"){ default_flag = params[i]; }
 	}

--- a/model/classes/Fintmpl.h
+++ b/model/classes/Fintmpl.h
@@ -1,0 +1,16 @@
+#ifndef XERPARSER_H_
+#define XERPARSER_H_
+
+#include <string>
+
+class Fintmpl{
+    public:
+        Fintmpl(const std::string header[], const std::string params[]);
+        std::string get_tsv();
+        int fintmpl_id;
+        std::string fintmpl_name;
+        std::string default_flag;
+};
+
+#endif // !XERPARSER_H_#define XERPARSER_H_
+

--- a/model/classes/NonWork.cpp
+++ b/model/classes/NonWork.cpp
@@ -7,8 +7,16 @@
 NonWork::NonWork(const std::string *header, const std::string *params){
 	tsv = "";
 	for(uint i = 0; i < header->size(); i++){
-		if (header[i] == "nonwork_type_id"){ nonwork_type_id = std::stoi(params[i]); }
-		else if (header[i] == "seq_num"){ seq_num = std::stoi(params[i]); }
+		if (header[i] == "nonwork_type_id"){ 
+			if(!params[i].empty()){
+				nonwork_type_id = std::stoi(params[i]); 
+				}
+		}
+		else if (header[i] == "seq_num"){ 
+		if(!params[i].empty()){
+			seq_num = std::stoi(params[i]); 
+			}
+		}
 		else if (header[i] == "nonwork_code"){ nonwork_code = params[i]; }
 		else if (header[i] == "nonwork_type"){ nonwork_type = params[i]; }
 	}

--- a/model/classes/Obs.cpp
+++ b/model/classes/Obs.cpp
@@ -7,12 +7,25 @@
 Obs::Obs(const std::string *header, const std::string *params){
 	tsv = "";
 	for (uint i = 0; i < header->size(); i++) {
-		if (header[i] == "obs_id"){ obs_id = stoi(params[i]); }
-		else if (header[i] == "guid"){ guid = stoi(params[i]); }
+		if (header[i] == "obs_id"){ 
+			if(!params[i].empty()){
+				obs_id = stoi(params[i]); }
+		}
+		else if (header[i] == "guid"){ 
+			if(!params[i].empty()){
+				guid = stoi(params[i]); }
+		}
 		else if (header[i] == "obs_name"){ obs_name = params[i]; }
 		else if (header[i] == "obs_descr"){ obs_descr = params[i]; }
-		else if (header[i] == "parent_obs_id"){ parent_obs_id = stoi(params[i]); }
-		else if (header[i] == "seq_num"){ seq_num = stoi(params[i]); }
+		else if (header[i] == "parent_obs_id"){ 
+			if(!params[i].empty()){
+				parent_obs_id = stoi(params[i]); 
+				}
+		}
+		else if (header[i] == "seq_num"){ 
+		if(!params[i].empty()){	
+			seq_num = stoi(params[i]); }
+		}
 	}
 	tsv.append(std::to_string(obs_id)).append("\t")
 	.append(std::to_string(obs_id)).append("\t")

--- a/model/classes/Pcattype.cpp
+++ b/model/classes/Pcattype.cpp
@@ -7,8 +7,16 @@
 Pcattype::Pcattype(const std::string *header, const std::string *params){
 	tsv = "";
 	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "proj_catg_type_id"){ proj_catg_type_id = stoi(params[i]);}
-		else if(header[i] == "seq_num"){ seq_num = stoi(params[i]);}
+		if(header[i] == "proj_catg_type_id"){ 
+			if(!params[i].empty()){
+				proj_catg_type_id = stoi(params[i]);
+			}
+		}
+		else if(header[i] == "seq_num"){ 
+			if(!params[i].empty()){
+				seq_num = stoi(params[i]);
+			}
+		}
 		else if(header[i] == "proj_catg_short_len"){ proj_catg_short_len = stoi(params[i]);}
 		else if(header[i] == "proj_catg_type"){ proj_catg_type = params[i]; }
 		else if(header[i] == "export_flag"){ export_flag = params[i];}

--- a/model/classes/Pcatval.cpp
+++ b/model/classes/Pcatval.cpp
@@ -7,10 +7,26 @@
 Pcatval::Pcatval(const std::string *header, const std::string *params){
 	tsv = "";
 	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "proj_catg_id"){ proj_catg_id = stoi(params[i]); }
-		else if(header[i] == "proj_catg_type_id"){ proj_catg_type_id = stoi(params[i]); }
-		else if(header[i] == "seq_num"){ seq_num = stoi(params[i]); }
-		else if(header[i] == "parent_proj_catg_id"){ parent_proj_catg_id = stoi(params[i]); }
+		if(header[i] == "proj_catg_id"){ 
+			if(!params[i].empty()){
+				proj_catg_id = stoi(params[i]); 
+				}
+		}
+		else if(header[i] == "proj_catg_type_id"){ 
+			if(!params[i].empty()){
+				proj_catg_type_id = stoi(params[i]); 
+			}
+		}
+		else if(header[i] == "seq_num"){ 
+			if(!params[i].empty()){
+				seq_num = stoi(params[i]); 
+			}
+		}
+		else if(header[i] == "parent_proj_catg_id"){ 
+			if(!params[i].empty()){
+				parent_proj_catg_id = stoi(params[i]); 
+			}
+		}
 		else if(header[i] == "proj_catg_short_name"){ proj_catg_short_name = params[i]; }
 		else if(header[i] == "proj_catg_name"){ proj_catg_name = params[i]; }
 	}

--- a/model/classes/Project.cpp
+++ b/model/classes/Project.cpp
@@ -4,148 +4,324 @@
 
 #include "Project.h"
 
-Project::Project(const std::string *header, const std::string *params){
+Project::Project(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "proj_id"){ proj_id = stoi(params[i]);}
-		else if(header[i] == "acct_id"){ acct_id = stoi(params[i]);}
-		else if(header[i] == "orig_proj_id"){ orig_proj_id = stoi(params[i]);}
-		else if(header[i] == "source_proj_id"){ source_proj_id = stoi(params[i]);}
-		else if(header[i] == "base_type_id"){ base_type_id = stoi(params[i]);}
-		else if(header[i] == "clndr_id"){ clndr_id = stoi(params[i]);}
-		else if(header[i] == "sum_base_proj_id"){ sum_base_proj_id = stoi(params[i]);}
-		else if(header[i] == "last_fin_dates_id"){ last_fin_dates_id = stoi(params[i]);}
-		else if(header[i] == "fintmpl_id"){ fintmpl_id = stoi(params[i]);}
-		else if(header[i] == "location_id"){ location_id = stoi(params[i]);}
-		else if(header[i] == "new_fin_dates_id"){ new_fin_dates_id = stoi(params[i]);}
-		else if(header[i] == "fy_start_month_num"){ fy_start_month_num = params[i];}
-		else if(header[i] == "rsrc_self_add_flag"){ rsrc_self_add_flag = params[i];}
-		else if(header[i] == "allow_complete_flag"){ allow_complete_flag = params[i];}
-		else if(header[i] == "rsrc_multi_assign_flag"){ rsrc_multi_assign_flag = params[i];}
-		else if(header[i] == "checkout_flag"){ checkout_flag = params[i];}
-		else if(header[i] == "project_flag"){ project_flag = params[i];}
-		else if(header[i] == "step_complete_flag"){ step_complete_flag = params[i];}
-		else if(header[i] == "cost_qty_recalc_flag"){ cost_qty_recalc_flag = params[i];}
-		else if(header[i] == "batch_sum_flag"){ batch_sum_flag = params[i];}
-		else if(header[i] == "name_sep_char"){ name_sep_char = params[i];}
-		else if(header[i] == "def_complete_pct_type"){ def_complete_pct_type = params[i];}
-		else if(header[i] == "proj_short_name"){ proj_short_name = params[i];}
-		else if(header[i] == "task_code_base"){ task_code_base = params[i];}
-		else if(header[i] == "task_code_step"){ task_code_step = params[i];}
-		else if(header[i] == "priority_num"){ priority_num = params[i];}
-		else if(header[i] == "wbs_max_sum_level"){ wbs_max_sum_level = params[i];}
-		else if(header[i] == "strgy_priority_num"){ strgy_priority_num = params[i];}
-		else if(header[i] == "last_checksum"){ last_checksum = params[i];}
-		else if(header[i] == "critical_drtn_hr_cnt"){ critical_drtn_hr_cnt = params[i];}
-		else if(header[i] == "def_cost_per_qty"){ def_cost_per_qty = params[i];}
-		else if(header[i] == "last_recalc_date"){ last_recalc_date = params[i];}
-		else if(header[i] == "plan_start_date"){ plan_start_date = params[i];}
-		else if(header[i] == "plan_end_date"){ plan_end_date = params[i];}
-		else if(header[i] == "scd_end_date"){ scd_end_date = params[i];}
-		else if(header[i] == "add_date"){ add_date = params[i];}
-		else if(header[i] == "last_tasksum_date"){ last_tasksum_date = params[i];}
-		else if(header[i] == "fcst_start_date"){ fcst_start_date = params[i];}
-		else if(header[i] == "def_duration_type"){ def_duration_type = params[i];}
-		else if(header[i] == "task_code_prefix"){ task_code_prefix = params[i];}
-		else if(header[i] == "guid"){ guid = params[i];}
-		else if(header[i] == "def_qty_type"){ def_qty_type = params[i];}
-		else if(header[i] == "add_by_name"){ add_by_name = params[i];}
-		else if(header[i] == "web_local_root_path"){ web_local_root_path = params[i];}
-		else if(header[i] == "proj_url"){ proj_url = params[i];}
-		else if(header[i] == "def_rate_type"){ def_rate_type = params[i];}
-		else if(header[i] == "add_act_remain_flag"){ add_act_remain_flag = params[i];}
-		else if(header[i] == "act_this_per_link_flag"){ act_this_per_link_flag = params[i];}
-		else if(header[i] == "def_task_type"){ def_task_type = params[i];}
-		else if(header[i] == "act_pct_link_flag"){ act_pct_link_flag = params[i];}
-		else if(header[i] == "critical_path_type"){ critical_path_type = params[i];}
-		else if(header[i] == "task_code_prefix_flag"){ task_code_prefix_flag = params[i];}
-		else if(header[i] == "def_rollup_dates_flag"){ def_rollup_dates_flag = params[i];}
-		else if(header[i] == "use_project_baseline_flag"){ use_project_baseline_flag = params[i];}
-		else if(header[i] == "rem_target_link_flag"){ rem_target_link_flag = params[i];}
-		else if(header[i] == "reset_planned_flag"){ reset_planned_flag = params[i];}
-		else if(header[i] == "allow_neg_act_flag"){ allow_neg_act_flag = params[i];}
-		else if(header[i] == "sum_assign_level"){ sum_assign_level = params[i];}
-		else if(header[i] == "last_baseline_update_date"){ last_baseline_update_date = params[i];}
-		else if(header[i] == "cr_external_key"){ cr_external_key = params[i];}
-		else if(header[i] == "apply_actuals_date"){ apply_actuals_date = params[i];}
-		else if(header[i] == "loaded_scope_level"){ loaded_scope_level = params[i];}
-		else if(header[i] == "export_flag"){ export_flag = params[i];}
-		else if(header[i] == "baselines_to_export"){ baselines_to_export = params[i];}
-		else if(header[i] == "baseline_names_to_export"){ baseline_names_to_export = params[i];}
-		else if(header[i] == "next_data_date"){ next_data_date = params[i];}
-		else if(header[i] == "close_period_flag"){ close_period_flag = params[i];}
-		else if(header[i] == "sum_refresh_date"){ sum_refresh_date = params[i];}
-		else if(header[i] == "trsrcsum_loaded"){ trsrcsum_loaded = params[i];}
-		else if(header[i] == "sumtask_loaded"){ sumtask_loaded = params[i];}
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "proj_id")
+		{
+			if (!params[i].empty())
+			{
+				proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "acct_id")
+		{
+			if (!params[i].empty())
+			{
+				acct_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "orig_proj_id")
+		{
+			if (!params[i].empty())
+			{
+				orig_proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "source_proj_id")
+		{
+			if (!params[i].empty())
+			{
+				source_proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "base_type_id")
+		{
+			if (!params[i].empty())
+			{
+				base_type_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "clndr_id")
+		{
+			if (!params[i].empty())
+			{
+				clndr_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sum_base_proj_id")
+		{
+			if (!params[i].empty())
+			{
+				sum_base_proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "last_fin_dates_id")
+		{
+			if (!params[i].empty())
+			{
+				last_fin_dates_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "fintmpl_id")
+		{
+			if (!params[i].empty())
+			{
+				fintmpl_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "location_id")
+		{
+			if (!params[i].empty())
+			{
+				location_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "new_fin_dates_id")
+		{
+			if (!params[i].empty())
+			{
+				new_fin_dates_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "fy_start_month_num")
+		{
+			fy_start_month_num = params[i];
+		}
+		else if (header[i] == "rsrc_self_add_flag")
+		{
+			rsrc_self_add_flag = params[i];
+		}
+		else if (header[i] == "allow_complete_flag")
+		{
+			allow_complete_flag = params[i];
+		}
+		else if (header[i] == "rsrc_multi_assign_flag")
+		{
+			rsrc_multi_assign_flag = params[i];
+		}
+		else if (header[i] == "checkout_flag")
+		{
+			checkout_flag = params[i];
+		}
+		else if (header[i] == "project_flag")
+		{
+			project_flag = params[i];
+		}
+		else if (header[i] == "step_complete_flag")
+		{
+			step_complete_flag = params[i];
+		}
+		else if (header[i] == "cost_qty_recalc_flag")
+		{
+			cost_qty_recalc_flag = params[i];
+		}
+		else if (header[i] == "batch_sum_flag")
+		{
+			batch_sum_flag = params[i];
+		}
+		else if (header[i] == "name_sep_char")
+		{
+			name_sep_char = params[i];
+		}
+		else if (header[i] == "def_complete_pct_type")
+		{
+			def_complete_pct_type = params[i];
+		}
+		else if (header[i] == "proj_short_name")
+		{
+			proj_short_name = params[i];
+		}
+		else if (header[i] == "task_code_base")
+		{
+			task_code_base = params[i];
+		}
+		else if (header[i] == "task_code_step")
+		{
+			task_code_step = params[i];
+		}
+		else if (header[i] == "priority_num")
+		{
+			priority_num = params[i];
+		}
+		else if (header[i] == "wbs_max_sum_level")
+		{
+			wbs_max_sum_level = params[i];
+		}
+		else if (header[i] == "strgy_priority_num")
+		{
+			strgy_priority_num = params[i];
+		}
+		else if (header[i] == "last_checksum")
+		{
+			last_checksum = params[i];
+		}
+		else if (header[i] == "critical_drtn_hr_cnt")
+		{
+			critical_drtn_hr_cnt = params[i];
+		}
+		else if (header[i] == "def_cost_per_qty")
+		{
+			def_cost_per_qty = params[i];
+		}
+		else if (header[i] == "last_recalc_date")
+		{
+			last_recalc_date = params[i];
+		}
+		else if (header[i] == "plan_start_date")
+		{
+			plan_start_date = params[i];
+		}
+		else if (header[i] == "plan_end_date")
+		{
+			plan_end_date = params[i];
+		}
+		else if (header[i] == "scd_end_date")
+		{
+			scd_end_date = params[i];
+		}
+		else if (header[i] == "add_date")
+		{
+			add_date = params[i];
+		}
+		else if (header[i] == "last_tasksum_date")
+		{
+			last_tasksum_date = params[i];
+		}
+		else if (header[i] == "fcst_start_date")
+		{
+			fcst_start_date = params[i];
+		}
+		else if (header[i] == "def_duration_type")
+		{
+			def_duration_type = params[i];
+		}
+		else if (header[i] == "task_code_prefix")
+		{
+			task_code_prefix = params[i];
+		}
+		else if (header[i] == "guid")
+		{
+			guid = params[i];
+		}
+		else if (header[i] == "def_qty_type")
+		{
+			def_qty_type = params[i];
+		}
+		else if (header[i] == "add_by_name")
+		{
+			add_by_name = params[i];
+		}
+		else if (header[i] == "web_local_root_path")
+		{
+			web_local_root_path = params[i];
+		}
+		else if (header[i] == "proj_url")
+		{
+			proj_url = params[i];
+		}
+		else if (header[i] == "def_rate_type")
+		{
+			def_rate_type = params[i];
+		}
+		else if (header[i] == "add_act_remain_flag")
+		{
+			add_act_remain_flag = params[i];
+		}
+		else if (header[i] == "act_this_per_link_flag")
+		{
+			act_this_per_link_flag = params[i];
+		}
+		else if (header[i] == "def_task_type")
+		{
+			def_task_type = params[i];
+		}
+		else if (header[i] == "act_pct_link_flag")
+		{
+			act_pct_link_flag = params[i];
+		}
+		else if (header[i] == "critical_path_type")
+		{
+			critical_path_type = params[i];
+		}
+		else if (header[i] == "task_code_prefix_flag")
+		{
+			task_code_prefix_flag = params[i];
+		}
+		else if (header[i] == "def_rollup_dates_flag")
+		{
+			def_rollup_dates_flag = params[i];
+		}
+		else if (header[i] == "use_project_baseline_flag")
+		{
+			use_project_baseline_flag = params[i];
+		}
+		else if (header[i] == "rem_target_link_flag")
+		{
+			rem_target_link_flag = params[i];
+		}
+		else if (header[i] == "reset_planned_flag")
+		{
+			reset_planned_flag = params[i];
+		}
+		else if (header[i] == "allow_neg_act_flag")
+		{
+			allow_neg_act_flag = params[i];
+		}
+		else if (header[i] == "sum_assign_level")
+		{
+			sum_assign_level = params[i];
+		}
+		else if (header[i] == "last_baseline_update_date")
+		{
+			last_baseline_update_date = params[i];
+		}
+		else if (header[i] == "cr_external_key")
+		{
+			cr_external_key = params[i];
+		}
+		else if (header[i] == "apply_actuals_date")
+		{
+			apply_actuals_date = params[i];
+		}
+		else if (header[i] == "loaded_scope_level")
+		{
+			loaded_scope_level = params[i];
+		}
+		else if (header[i] == "export_flag")
+		{
+			export_flag = params[i];
+		}
+		else if (header[i] == "baselines_to_export")
+		{
+			baselines_to_export = params[i];
+		}
+		else if (header[i] == "baseline_names_to_export")
+		{
+			baseline_names_to_export = params[i];
+		}
+		else if (header[i] == "next_data_date")
+		{
+			next_data_date = params[i];
+		}
+		else if (header[i] == "close_period_flag")
+		{
+			close_period_flag = params[i];
+		}
+		else if (header[i] == "sum_refresh_date")
+		{
+			sum_refresh_date = params[i];
+		}
+		else if (header[i] == "trsrcsum_loaded")
+		{
+			trsrcsum_loaded = params[i];
+		}
+		else if (header[i] == "sumtask_loaded")
+		{
+			sumtask_loaded = params[i];
+		}
 	}
-	tsv.append(std::to_string(proj_id)).append("\t")
-	.append(std::to_string(acct_id)).append("\t")
-	.append(std::to_string(orig_proj_id)).append("\t")
-	.append(std::to_string(source_proj_id)).append("\t")
-	.append(std::to_string(base_type_id)).append("\t")
-	.append(std::to_string(clndr_id)).append("\t")
-	.append(std::to_string(sum_base_proj_id)).append("\t")
-	.append(std::to_string(last_fin_dates_id)).append("\t")
-	.append(std::to_string(fintmpl_id)).append("\t")
-	.append(std::to_string(location_id)).append("\t")
-	.append(std::to_string(new_fin_dates_id)).append("\t")
-	.append(fy_start_month_num).append("\t")
-	.append(rsrc_self_add_flag).append("\t")
-	.append(allow_complete_flag).append("\t")
-	.append(rsrc_multi_assign_flag).append("\t")
-	.append(checkout_flag).append("\t")
-	.append(project_flag).append("\t")
-	.append(step_complete_flag).append("\t")
-	.append(cost_qty_recalc_flag).append("\t")
-	.append(batch_sum_flag).append("\t")
-	.append(name_sep_char).append("\t")
-	.append(def_complete_pct_type).append("\t")
-	.append(proj_short_name).append("\t")
-	.append(task_code_base).append("\t")
-	.append(task_code_step).append("\t")
-	.append(priority_num).append("\t")
-	.append(wbs_max_sum_level).append("\t")
-	.append(strgy_priority_num).append("\t")
-	.append(last_checksum).append("\t")
-	.append(critical_drtn_hr_cnt).append("\t")
-	.append(def_cost_per_qty).append("\t")
-	.append(last_recalc_date).append("\t")
-	.append(plan_start_date).append("\t")
-	.append(plan_end_date).append("\t")
-	.append(scd_end_date).append("\t")
-	.append(add_date).append("\t")
-	.append(last_tasksum_date).append("\t")
-	.append(fcst_start_date).append("\t")
-	.append(def_duration_type).append("\t")
-	.append(task_code_prefix).append("\t")
-	.append(guid).append("\t")
-	.append(def_qty_type).append("\t")
-	.append(add_by_name).append("\t")
-	.append(web_local_root_path).append("\t")
-	.append(proj_url).append("\t")
-	.append(def_rate_type).append("\t")
-	.append(add_act_remain_flag).append("\t")
-	.append(act_this_per_link_flag).append("\t")
-	.append(def_task_type).append("\t")
-	.append(act_pct_link_flag).append("\t")
-	.append(critical_path_type).append("\t")
-	.append(task_code_prefix_flag).append("\t")
-	.append(def_rollup_dates_flag).append("\t")
-	.append(use_project_baseline_flag).append("\t")
-	.append(rem_target_link_flag).append("\t")
-	.append(reset_planned_flag).append("\t")
-	.append(allow_neg_act_flag).append("\t")
-	.append(sum_assign_level).append("\t")
-	.append(last_baseline_update_date).append("\t")
-	.append(cr_external_key).append("\t")
-	.append(apply_actuals_date).append("\t")
-	.append(loaded_scope_level).append("\t")
-	.append(export_flag).append("\t")
-	.append(baselines_to_export).append("\t")
-	.append(baseline_names_to_export).append("\t")
-	.append(next_data_date).append("\t")
-	.append(close_period_flag).append("\t")
-	.append(sum_refresh_date).append("\t")
-	.append(trsrcsum_loaded).append("\t")
-	.append(sumtask_loaded).append("\n");
+	tsv.append(std::to_string(proj_id)).append("\t").append(std::to_string(acct_id)).append("\t").append(std::to_string(orig_proj_id)).append("\t").append(std::to_string(source_proj_id)).append("\t").append(std::to_string(base_type_id)).append("\t").append(std::to_string(clndr_id)).append("\t").append(std::to_string(sum_base_proj_id)).append("\t").append(std::to_string(last_fin_dates_id)).append("\t").append(std::to_string(fintmpl_id)).append("\t").append(std::to_string(location_id)).append("\t").append(std::to_string(new_fin_dates_id)).append("\t").append(fy_start_month_num).append("\t").append(rsrc_self_add_flag).append("\t").append(allow_complete_flag).append("\t").append(rsrc_multi_assign_flag).append("\t").append(checkout_flag).append("\t").append(project_flag).append("\t").append(step_complete_flag).append("\t").append(cost_qty_recalc_flag).append("\t").append(batch_sum_flag).append("\t").append(name_sep_char).append("\t").append(def_complete_pct_type).append("\t").append(proj_short_name).append("\t").append(task_code_base).append("\t").append(task_code_step).append("\t").append(priority_num).append("\t").append(wbs_max_sum_level).append("\t").append(strgy_priority_num).append("\t").append(last_checksum).append("\t").append(critical_drtn_hr_cnt).append("\t").append(def_cost_per_qty).append("\t").append(last_recalc_date).append("\t").append(plan_start_date).append("\t").append(plan_end_date).append("\t").append(scd_end_date).append("\t").append(add_date).append("\t").append(last_tasksum_date).append("\t").append(fcst_start_date).append("\t").append(def_duration_type).append("\t").append(task_code_prefix).append("\t").append(guid).append("\t").append(def_qty_type).append("\t").append(add_by_name).append("\t").append(web_local_root_path).append("\t").append(proj_url).append("\t").append(def_rate_type).append("\t").append(add_act_remain_flag).append("\t").append(act_this_per_link_flag).append("\t").append(def_task_type).append("\t").append(act_pct_link_flag).append("\t").append(critical_path_type).append("\t").append(task_code_prefix_flag).append("\t").append(def_rollup_dates_flag).append("\t").append(use_project_baseline_flag).append("\t").append(rem_target_link_flag).append("\t").append(reset_planned_flag).append("\t").append(allow_neg_act_flag).append("\t").append(sum_assign_level).append("\t").append(last_baseline_update_date).append("\t").append(cr_external_key).append("\t").append(apply_actuals_date).append("\t").append(loaded_scope_level).append("\t").append(export_flag).append("\t").append(baselines_to_export).append("\t").append(baseline_names_to_export).append("\t").append(next_data_date).append("\t").append(close_period_flag).append("\t").append(sum_refresh_date).append("\t").append(trsrcsum_loaded).append("\t").append(sumtask_loaded).append("\n");
 }

--- a/model/classes/Projpcat.cpp
+++ b/model/classes/Projpcat.cpp
@@ -4,15 +4,39 @@
 
 #include "Projpcat.h"
 
-Projpcat::Projpcat(const std::string *header, const std::string *params){
+Projpcat::Projpcat(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "proj_id"){ proj_id = stoi(params[i]);}
-		else if(header[i] == "proj_catg_type_id"){ proj_catg_type_id = stoi(params[i]);}
-		else if(header[i] == "proj_catg_id"){ proj_catg_id = stoi(params[i]);}
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "proj_id")
+		{
+			if (!params[i].empty())
+			{
+				proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "proj_catg_type_id")
+		{
+			if (!params[i].empty())
+			{
+				proj_catg_type_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "proj_catg_id")
+		{
+			if (!params[i].empty())
+			{
+
+				proj_catg_id = stoi(params[i]);
+			}
+		}
 	}
 	tsv
-	.append(std::to_string(proj_id)).append("\t")
-	.append(std::to_string(proj_catg_type_id)).append("\t")
-	.append(std::to_string(proj_catg_id)).append("\n");
+		.append(std::to_string(proj_id))
+		.append("\t")
+		.append(std::to_string(proj_catg_type_id))
+		.append("\t")
+		.append(std::to_string(proj_catg_id))
+		.append("\n");
 }

--- a/model/classes/Role.cpp
+++ b/model/classes/Role.cpp
@@ -1,6 +1,7 @@
 #include "Role.h"
+#include "../../Reader.h"
 
-Role::Role(const std::string header[], const std::string params[]){
+Role::Role(const std::string header[], const std::string params[], Reader *readerObj){
     for (int i = 0; i < header->length(); i++){
         if(header[i].empty()) break;
         if (header[i] == "role_id"){
@@ -33,6 +34,7 @@ Role::Role(const std::string header[], const std::string params[]){
             last_checksum = params[i];
         }
     }
+    reader = readerObj;
 }
 
 std::string Role::get_tsv(){
@@ -48,4 +50,11 @@ std::string Role::get_tsv(){
         .append(role_descr).append("\t")
         .append(last_checksum).append("\n");
     return tsv;
+}
+
+std::vector<RoleRate> Role::getRoleRate(){
+    std::vector<RoleRate> rates;
+
+    reader->roleRates.getAll();
+    return rates;
 }

--- a/model/classes/Role.cpp
+++ b/model/classes/Role.cpp
@@ -47,4 +47,5 @@ std::string Role::get_tsv(){
         .append(cost_qty_type).append("\t")
         .append(role_descr).append("\t")
         .append(last_checksum).append("\n");
+    return tsv;
 }

--- a/model/classes/Role.h
+++ b/model/classes/Role.h
@@ -3,11 +3,13 @@
 
 #include <vector>
 #include<string>
-
+#include "../RoleRates.h"
+class Reader;
 
 class Role
 {
 public:
+    Role(Reader *reader);
     int role_id;
     int parent_role_id;
     int seq_num;
@@ -19,11 +21,15 @@ public:
     std::string role_descr;
     std::string last_checksum;
 
-    Role(const std::string *header, const std::string *params);
+    Role(const std::string *header, const std::string *params, Reader *reader);
     std::string get_tsv();
+    std::vector<RoleRate> getRoleRate();
+    
 
 private:
     std::string tsv;
+    RoleRates roleRates;
+    Reader * reader;
 };
 
 #endif //XERPARSER_ROLE_H

--- a/model/classes/Rsrc.cpp
+++ b/model/classes/Rsrc.cpp
@@ -3,70 +3,232 @@
 //
 
 #include "Rsrc.h"
+#include "../../Reader.h"
 
-Rsrc::Rsrc(const std::string *header, const std::string *params){
+Rsrc::Rsrc(const std::string *header, const std::string *params, Reader *readerObj)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "rsrc_id"){ rsrc_id = stoi(params[i]);}
-		else if(header[i] == "parent_rsrc_id"){ parent_rsrc_id = stoi(params[i]);}
-		else if(header[i] == "clndr_id"){ clndr_id = stoi(params[i]);}
-		else if(header[i] == "role_id"){ role_id = stoi(params[i]);}
-		else if(header[i] == "shift_id"){ shift_id = stoi(params[i]);}
-		else if(header[i] == "user_id"){ user_id = stoi(params[i]);}
-		else if(header[i] == "pobs_id"){ pobs_id = stoi(params[i]);}
-		else if(header[i] == "rsrc_seq_num"){ rsrc_seq_num = stoi(params[i]);}
-		else if(header[i] == "curr_id"){ curr_id = stoi(params[i]);}
-		else if(header[i] == "unit_id"){ unit_id = stoi(params[i]);}
-		else if(header[i] == "location_id"){ location_id = stoi(params[i]);}
-		else if(header[i] == "guid"){ guid = params[i];}
-		else if(header[i] == "email_addr"){ email_addr = params[i];}
-		else if(header[i] == "employee_code"){ employee_code = params[i];}
-		else if(header[i] == "office_phone"){ office_phone = params[i];}
-		else if(header[i] == "rsrc_name"){ rsrc_name = params[i];}
-		else if(header[i] == "rsrc_short_name"){ rsrc_short_name = params[i];}
-		else if(header[i] == "rsrc_title_name"){ rsrc_title_name = params[i];}
-		else if(header[i] == "def_qty_per_hr"){ def_qty_per_hr = params[i];}
-		else if(header[i] == "cost_qty_type"){ cost_qty_type = params[i];}
-		else if(header[i] == "ot_factor"){ ot_factor = params[i];}
-		else if(header[i] == "active_flag"){ active_flag = params[i];}
-		else if(header[i] == "auto_compute_act_flag"){ auto_compute_act_flag = params[i];}
-		else if(header[i] == "ot_flag"){ ot_flag = params[i];}
-		else if(header[i] == "rsrc_type"){ rsrc_type = params[i];}
-		else if(header[i] == "rsrc_notes"){ rsrc_notes = params[i];}
-		else if(header[i] == "load_tasks_flag"){ load_tasks_flag = params[i];}
-		else if(header[i] == "level_flag"){ level_flag = params[i];}
-		else if(header[i] == "last_checksum"){ last_checksum = params[i];}
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "rsrc_id")
+		{
+			if (!params[i].empty())
+			{
+				rsrc_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "parent_rsrc_id")
+		{
+			if (!params[i].empty())
+			{
+				parent_rsrc_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "clndr_id")
+		{
+			if (!params[i].empty())
+			{
+				clndr_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "role_id")
+		{
+			if (!params[i].empty())
+			{
+				role_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "shift_id")
+		{
+			if (!params[i].empty())
+			{
+				shift_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "user_id")
+		{
+			if (!params[i].empty())
+			{
+				user_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "pobs_id")
+		{
+			if (!params[i].empty())
+			{
+				pobs_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "rsrc_seq_num")
+		{
+			if (!params[i].empty())
+			{
+				rsrc_seq_num = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "curr_id")
+		{
+			if (!params[i].empty())
+			{
+				curr_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "unit_id")
+		{
+			if (!params[i].empty())
+			{
+				unit_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "location_id")
+		{
+			if (!params[i].empty())
+			{
+				location_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "guid")
+		{
+			guid = params[i];
+		}
+		else if (header[i] == "email_addr")
+		{
+			email_addr = params[i];
+		}
+		else if (header[i] == "employee_code")
+		{
+			employee_code = params[i];
+		}
+		else if (header[i] == "office_phone")
+		{
+			office_phone = params[i];
+		}
+		else if (header[i] == "rsrc_name")
+		{
+			rsrc_name = params[i];
+		}
+		else if (header[i] == "rsrc_short_name")
+		{
+			rsrc_short_name = params[i];
+		}
+		else if (header[i] == "rsrc_title_name")
+		{
+			rsrc_title_name = params[i];
+		}
+		else if (header[i] == "def_qty_per_hr")
+		{
+			def_qty_per_hr = params[i];
+		}
+		else if (header[i] == "cost_qty_type")
+		{
+			cost_qty_type = params[i];
+		}
+		else if (header[i] == "ot_factor")
+		{
+			ot_factor = params[i];
+		}
+		else if (header[i] == "active_flag")
+		{
+			active_flag = params[i];
+		}
+		else if (header[i] == "auto_compute_act_flag")
+		{
+			auto_compute_act_flag = params[i];
+		}
+		else if (header[i] == "ot_flag")
+		{
+			ot_flag = params[i];
+		}
+		else if (header[i] == "rsrc_type")
+		{
+			rsrc_type = params[i];
+		}
+		else if (header[i] == "rsrc_notes")
+		{
+			rsrc_notes = params[i];
+		}
+		else if (header[i] == "load_tasks_flag")
+		{
+			load_tasks_flag = params[i];
+		}
+		else if (header[i] == "level_flag")
+		{
+			level_flag = params[i];
+		}
+		else if (header[i] == "last_checksum")
+		{
+			last_checksum = params[i];
+		}
 	}
+	reader = readerObj;
 	tsv
-	.append(std::to_string(rsrc_id)).append("\t")
-	.append(std::to_string(parent_rsrc_id)).append("\t")
-	.append(std::to_string(clndr_id)).append("\t")
-	.append(std::to_string(role_id)).append("\t")
-	.append(std::to_string(shift_id)).append("\t")
-	.append(std::to_string(user_id)).append("\t")
-	.append(std::to_string(pobs_id)).append("\t")
-	.append(std::to_string(rsrc_seq_num)).append("\t")
-	.append(std::to_string(curr_id)).append("\t")
-	.append(std::to_string(unit_id)).append("\t")
-	.append(std::to_string(location_id)).append("\t")
-	.append(guid).append("\t")
-	.append(email_addr).append("\t")
-	.append(employee_code).append("\t")
-	.append(office_phone).append("\t")
-	.append(other_phone).append("\t")
-	.append(rsrc_name).append("\t")
-	.append(rsrc_short_name).append("\t")
-	.append(rsrc_title_name).append("\t")
-	.append(def_qty_per_hr).append("\t")
-	.append(cost_qty_type).append("\t")
-	.append(ot_factor).append("\t")
-	.append(active_flag).append("\t")
-	.append(auto_compute_act_flag).append("\t")
-	.append(def_cost_qty_link_flag).append("\t")
-	.append(ot_flag).append("\t")
-	.append(rsrc_type).append("\t")
-	.append(rsrc_notes).append("\t")
-	.append(load_tasks_flag).append("\t")
-	.append(level_flag).append("\t")
-	.append(last_checksum).append("\n");
+		.append(std::to_string(rsrc_id))
+		.append("\t")
+		.append(std::to_string(parent_rsrc_id))
+		.append("\t")
+		.append(std::to_string(clndr_id))
+		.append("\t")
+		.append(std::to_string(role_id))
+		.append("\t")
+		.append(std::to_string(shift_id))
+		.append("\t")
+		.append(std::to_string(user_id))
+		.append("\t")
+		.append(std::to_string(pobs_id))
+		.append("\t")
+		.append(std::to_string(rsrc_seq_num))
+		.append("\t")
+		.append(std::to_string(curr_id))
+		.append("\t")
+		.append(std::to_string(unit_id))
+		.append("\t")
+		.append(std::to_string(location_id))
+		.append("\t")
+		.append(guid)
+		.append("\t")
+		.append(email_addr)
+		.append("\t")
+		.append(employee_code)
+		.append("\t")
+		.append(office_phone)
+		.append("\t")
+		.append(other_phone)
+		.append("\t")
+		.append(rsrc_name)
+		.append("\t")
+		.append(rsrc_short_name)
+		.append("\t")
+		.append(rsrc_title_name)
+		.append("\t")
+		.append(def_qty_per_hr)
+		.append("\t")
+		.append(cost_qty_type)
+		.append("\t")
+		.append(ot_factor)
+		.append("\t")
+		.append(active_flag)
+		.append("\t")
+		.append(auto_compute_act_flag)
+		.append("\t")
+		.append(def_cost_qty_link_flag)
+		.append("\t")
+		.append(ot_flag)
+		.append("\t")
+		.append(rsrc_type)
+		.append("\t")
+		.append(rsrc_notes)
+		.append("\t")
+		.append(load_tasks_flag)
+		.append("\t")
+		.append(level_flag)
+		.append("\t")
+		.append(last_checksum)
+		.append("\n");
+}
+
+std::vector<Rsrcrate> Rsrc::getRsrcRate()
+{
+	std::vector<Rsrcrate> toReturn;
+	toReturn = reader->rsrcrates.getAll();
+	return toReturn;
 }

--- a/model/classes/Rsrc.h
+++ b/model/classes/Rsrc.h
@@ -6,45 +6,51 @@
 #define XERPARSER_RSRC_H
 
 #include <iostream>
+#include "../Rsrcrates.h"
 
-class Rsrc{
+class Reader;
+
+class Rsrc
+{
 public:
-		int rsrc_id;
-		int parent_rsrc_id;
-		int clndr_id;
-		int role_id;
-		int shift_id;
-		int user_id;
-		int pobs_id;
-		int rsrc_seq_num;
-		int curr_id;
-		int unit_id;
-		int location_id;
-		std::string guid;
-		std::string email_addr;
-		std::string employee_code;
-		std::string office_phone;
-		std::string other_phone;
-		std::string rsrc_name;
-		std::string rsrc_short_name;
-		std::string rsrc_title_name;
-		std::string def_qty_per_hr;
-		std::string cost_qty_type;
-		std::string ot_factor;
-		std::string active_flag;
-		std::string auto_compute_act_flag;
-		std::string def_cost_qty_link_flag;
-		std::string ot_flag;
-		std::string rsrc_type;
-		std::string rsrc_notes;
-		std::string load_tasks_flag;
-		std::string level_flag;
-		std::string last_checksum;
+	int rsrc_id;
+	int parent_rsrc_id;
+	int clndr_id;
+	int role_id;
+	int shift_id;
+	int user_id;
+	int pobs_id;
+	int rsrc_seq_num;
+	int curr_id;
+	int unit_id;
+	int location_id;
+	std::string guid;
+	std::string email_addr;
+	std::string employee_code;
+	std::string office_phone;
+	std::string other_phone;
+	std::string rsrc_name;
+	std::string rsrc_short_name;
+	std::string rsrc_title_name;
+	std::string def_qty_per_hr;
+	std::string cost_qty_type;
+	std::string ot_factor;
+	std::string active_flag;
+	std::string auto_compute_act_flag;
+	std::string def_cost_qty_link_flag;
+	std::string ot_flag;
+	std::string rsrc_type;
+	std::string rsrc_notes;
+	std::string load_tasks_flag;
+	std::string level_flag;
+	std::string last_checksum;
+	std::vector<Rsrcrate> getRsrcRate();
+	std::string tsv;
 
-		std::string tsv;
+	Rsrc(const std::string *header, const std::string *params, Reader *readerObj);
 
-		Rsrc(const std::string *header, const std::string *params);
+private:
+	Reader *reader;
 };
 
-
-#endif //XERPARSER_RSRC_H
+#endif // XERPARSER_RSRC_H

--- a/model/classes/Rsrccurvdata.cpp
+++ b/model/classes/Rsrccurvdata.cpp
@@ -4,56 +4,110 @@
 
 #include "Rsrccurvdata.h"
 
-Rsrccurvdata::Rsrccurvdata(const std::string *header, const std::string *params){
+Rsrccurvdata::Rsrccurvdata(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "curv_id"){ curv_id = stoi(params[i]); }
-		else if(header[i] == "curv_name"){ curv_name = params[i]; }
-		else if(header[i] == "default_flag"){ default_flag = params[i]; }
-		else if(header[i] == "pct_usage_0"){ pct_usage_0 = params[i]; }
-		else if(header[i] == "pct_usage_1"){ pct_usage_1 = params[i]; }
-		else if(header[i] == "pct_usage_2"){ pct_usage_2 = params[i]; }
-		else if(header[i] == "pct_usage_3"){ pct_usage_3 = params[i]; }
-		else if(header[i] == "pct_usage_4"){ pct_usage_4 = params[i]; }
-		else if(header[i] == "pct_usage_5"){ pct_usage_5 = params[i]; }
-		else if(header[i] == "pct_usage_6"){ pct_usage_6 = params[i]; }
-		else if(header[i] == "pct_usage_7"){ pct_usage_7 = params[i]; }
-		else if(header[i] == "pct_usage_8	"){ pct_usage_8 = params[i]; }
-		else if(header[i] == "pct_usage_9"){ pct_usage_9 = params[i]; }
-		else if(header[i] == "pct_usage_10"){ pct_usage_10 = params[i]; }
-		else if(header[i] == "pct_usage_11"){ pct_usage_11 = params[i]; }
-		else if(header[i] == "pct_usage_12"){ pct_usage_12 = params[i]; }
-		else if(header[i] == "pct_usage_13"){ pct_usage_13 = params[i]; }
-		else if(header[i] == "pct_usage_14"){ pct_usage_14 = params[i]; }
-		else if(header[i] == "pct_usage_15"){ pct_usage_15 = params[i]; }
-		else if(header[i] == "pct_usage_16"){ pct_usage_16 = params[i]; }
-		else if(header[i] == "pct_usage_17"){ pct_usage_17 = params[i]; }
-		else if(header[i] == "pct_usage_18"){ pct_usage_18 = params[i]; }
-		else if(header[i] == "pct_usage_19"){ pct_usage_19 = params[i]; }
-		else if(header[i] == "pct_usage_20"){ pct_usage_20 = params[i]; }
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "curv_id")
+		{
+			if (!params[i].empty())
+			{
+				curv_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "curv_name")
+		{
+			curv_name = params[i];
+		}
+		else if (header[i] == "default_flag")
+		{
+			default_flag = params[i];
+		}
+		else if (header[i] == "pct_usage_0")
+		{
+			pct_usage_0 = params[i];
+		}
+		else if (header[i] == "pct_usage_1")
+		{
+			pct_usage_1 = params[i];
+		}
+		else if (header[i] == "pct_usage_2")
+		{
+			pct_usage_2 = params[i];
+		}
+		else if (header[i] == "pct_usage_3")
+		{
+			pct_usage_3 = params[i];
+		}
+		else if (header[i] == "pct_usage_4")
+		{
+			pct_usage_4 = params[i];
+		}
+		else if (header[i] == "pct_usage_5")
+		{
+			pct_usage_5 = params[i];
+		}
+		else if (header[i] == "pct_usage_6")
+		{
+			pct_usage_6 = params[i];
+		}
+		else if (header[i] == "pct_usage_7")
+		{
+			pct_usage_7 = params[i];
+		}
+		else if (header[i] == "pct_usage_8	")
+		{
+			pct_usage_8 = params[i];
+		}
+		else if (header[i] == "pct_usage_9")
+		{
+			pct_usage_9 = params[i];
+		}
+		else if (header[i] == "pct_usage_10")
+		{
+			pct_usage_10 = params[i];
+		}
+		else if (header[i] == "pct_usage_11")
+		{
+			pct_usage_11 = params[i];
+		}
+		else if (header[i] == "pct_usage_12")
+		{
+			pct_usage_12 = params[i];
+		}
+		else if (header[i] == "pct_usage_13")
+		{
+			pct_usage_13 = params[i];
+		}
+		else if (header[i] == "pct_usage_14")
+		{
+			pct_usage_14 = params[i];
+		}
+		else if (header[i] == "pct_usage_15")
+		{
+			pct_usage_15 = params[i];
+		}
+		else if (header[i] == "pct_usage_16")
+		{
+			pct_usage_16 = params[i];
+		}
+		else if (header[i] == "pct_usage_17")
+		{
+			pct_usage_17 = params[i];
+		}
+		else if (header[i] == "pct_usage_18")
+		{
+			pct_usage_18 = params[i];
+		}
+		else if (header[i] == "pct_usage_19")
+		{
+			pct_usage_19 = params[i];
+		}
+		else if (header[i] == "pct_usage_20")
+		{
+			pct_usage_20 = params[i];
+		}
 	}
-	tsv.append(std::to_string(curv_id)).append("\t")
-	.append(curv_name).append("\t")
-	.append(default_flag).append("\t")
-	.append(pct_usage_0).append("\t")
-	.append(pct_usage_1).append("\t")
-	.append(pct_usage_2).append("\t")
-	.append(pct_usage_3).append("\t")
-	.append(pct_usage_4).append("\t")
-	.append(pct_usage_5).append("\t")
-	.append(pct_usage_6).append("\t")
-	.append(pct_usage_7).append("\t")
-	.append(pct_usage_8).append("\t")
-	.append(pct_usage_9).append("\t")
-	.append(pct_usage_10).append("\t")
-	.append(pct_usage_11).append("\t")
-	.append(pct_usage_12).append("\t")
-	.append(pct_usage_13).append("\t")
-	.append(pct_usage_14).append("\t")
-	.append(pct_usage_15).append("\t")
-	.append(pct_usage_16).append("\t")
-	.append(pct_usage_17).append("\t")
-	.append(pct_usage_18).append("\t")
-	.append(pct_usage_19).append("\t")
-	.append(pct_usage_20).append("\n");
+	tsv.append(std::to_string(curv_id)).append("\t").append(curv_name).append("\t").append(default_flag).append("\t").append(pct_usage_0).append("\t").append(pct_usage_1).append("\t").append(pct_usage_2).append("\t").append(pct_usage_3).append("\t").append(pct_usage_4).append("\t").append(pct_usage_5).append("\t").append(pct_usage_6).append("\t").append(pct_usage_7).append("\t").append(pct_usage_8).append("\t").append(pct_usage_9).append("\t").append(pct_usage_10).append("\t").append(pct_usage_11).append("\t").append(pct_usage_12).append("\t").append(pct_usage_13).append("\t").append(pct_usage_14).append("\t").append(pct_usage_15).append("\t").append(pct_usage_16).append("\t").append(pct_usage_17).append("\t").append(pct_usage_18).append("\t").append(pct_usage_19).append("\t").append(pct_usage_20).append("\n");
 }

--- a/model/classes/Rsrcrate.cpp
+++ b/model/classes/Rsrcrate.cpp
@@ -4,29 +4,98 @@
 
 #include "Rsrcrate.h"
 
-Rsrcrate::Rsrcrate(const std::string *header, const std::string *params){
+Rsrcrate::Rsrcrate(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "rsrc_rate"){ rsrc_rate = stoi(params[i]);}
-		else if(header[i] == "rsrc_id"){ rsrc_id = stoi(params[i]); }
-		else if(header[i] == "max_qty_per_hr"){ max_qty_per_hr = stoi(params[i]); }
-		else if(header[i] == "cost_per_qty"){ cost_per_qty = stoi(params[i]); }
-		else if(header[i] == "cost_per_qty2"){ cost_per_qty2 = stoi(params[i]); }
-		else if(header[i] == "cost_per_qty3"){ cost_per_qty3 = stoi(params[i]);}
-		else if(header[i] == "cost_per_qty4"){ cost_per_qty4 = stoi(params[i]); }
-		else if(header[i] == "cost_per_qty5"){ cost_per_qty5 = stoi(params[i]); }
-		else if(header[i] == "shift_period_id"){ shift_period_id = stoi(params[i]); }
-		else if(header[i] == "start_date"){ start_date = Date(params[i]); }
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "rsrc_rate")
+		{
+			if (!params[i].empty())
+			{
+				rsrc_rate = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "rsrc_id")
+		{
+			if (!params[i].empty())
+			{
+				rsrc_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "max_qty_per_hr")
+		{
+			if (!params[i].empty())
+			{
+				max_qty_per_hr = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "cost_per_qty")
+		{
+			if (!params[i].empty())
+			{
+				cost_per_qty = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "cost_per_qty2")
+		{
+			if (!params[i].empty())
+			{
+				cost_per_qty2 = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "cost_per_qty3")
+		{
+			if (!params[i].empty())
+			{
+				cost_per_qty3 = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "cost_per_qty4")
+		{
+			if (!params[i].empty())
+			{
+				cost_per_qty4 = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "cost_per_qty5")
+		{
+			if (!params[i].empty())
+			{
+				cost_per_qty5 = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "shift_period_id")
+		{
+			if (!params[i].empty())
+			{
+				shift_period_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "start_date")
+		{
+			start_date = Date(params[i]);
+		}
 	}
 	tsv
-	.append(std::to_string(rsrc_rate)).append("\t")
-	.append(std::to_string(rsrc_id)).append("\t")
-	.append(std::to_string(max_qty_per_hr)).append("\t")
-	.append(std::to_string(cost_per_qty)).append("\t")
-	.append(std::to_string(cost_per_qty2)).append("\t")
-	.append(std::to_string(cost_per_qty3)).append("\t")
-	.append(std::to_string(cost_per_qty4)).append("\t")
-	.append(std::to_string(cost_per_qty5)).append("\t")
-	.append(std::to_string(shift_period_id)).append("\t")
-	.append(start_date.to_string()).append("\n");
+		.append(std::to_string(rsrc_rate))
+		.append("\t")
+		.append(std::to_string(rsrc_id))
+		.append("\t")
+		.append(std::to_string(max_qty_per_hr))
+		.append("\t")
+		.append(std::to_string(cost_per_qty))
+		.append("\t")
+		.append(std::to_string(cost_per_qty2))
+		.append("\t")
+		.append(std::to_string(cost_per_qty3))
+		.append("\t")
+		.append(std::to_string(cost_per_qty4))
+		.append("\t")
+		.append(std::to_string(cost_per_qty5))
+		.append("\t")
+		.append(std::to_string(shift_period_id))
+		.append("\t")
+		.append(start_date.to_string())
+		.append("\n");
 }

--- a/model/classes/Rsrcrcat.cpp
+++ b/model/classes/Rsrcrcat.cpp
@@ -4,14 +4,32 @@
 
 #include "Rsrcrcat.h"
 
-Rsrcrcat::Rsrcrcat(const std::string *header, const std::string *params){
+Rsrcrcat::Rsrcrcat(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "rsrc_id"){ rsrc_id = stoi(params[i]);}
-		else if(header[i] == "rsrc_catg_type_id"){ rsrc_catg_type_id = stoi(params[i]);}
-		else if(header[i] == "rsrc_catg_id"){ rsrc_catg_id = stoi(params[i]);}
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "rsrc_id")
+		{
+			if (!params[i].empty())
+			{
+				rsrc_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "rsrc_catg_type_id")
+		{
+			if (!params[i].empty())
+			{
+				rsrc_catg_type_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "rsrc_catg_id")
+		{
+			if (!params[i].empty())
+			{
+				rsrc_catg_id = stoi(params[i]);
+			}
+		}
 	}
-	tsv.append(std::to_string(rsrc_id)).append("\t")
-	.append(std::to_string(rsrc_catg_type_id)).append("\t")
-	.append(std::to_string(rsrc_catg_id)).append("\n");
+	tsv.append(std::to_string(rsrc_id)).append("\t").append(std::to_string(rsrc_catg_type_id)).append("\t").append(std::to_string(rsrc_catg_id)).append("\n");
 }

--- a/model/classes/Schedoption.cpp
+++ b/model/classes/Schedoption.cpp
@@ -4,58 +4,186 @@
 
 #include "Schedoption.h"
 
-Schedoption::Schedoption(const std::string *header, const std::string *params){
+Schedoption::Schedoption(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(int i = 0; i < params->length(); i++){
-		if(header[i] == "schedoptions_id"){ schedoptions_id = stoi(params[i]); }
-		else if(header[i] == "proj_id"){ proj_id = stoi(params[i]); }
-		else if(header[i] == "sched_outer_depend_type"){ sched_outer_depend_type = stoi(params[i]); }
-		else if(header[i] == "sched_open_critical_flag"){ sched_open_critical_flag = stoi(params[i]); }
-		else if(header[i] == "sched_lag_early_start_flag"){ sched_lag_early_start_flag = stoi(params[i]); }
-		else if(header[i] == "sched_retained_logic"){ sched_retained_logic = stoi(params[i]); }
-		else if(header[i] == "sched_setplantoforecast"){ sched_setplantoforecast = stoi(params[i]); }
-		else if(header[i] == "sched_float_type"){ sched_float_type = stoi(params[i]); }
-		else if(header[i] == "sched_calendar_on_relationship_lag"){ sched_calendar_on_relationship_lag = stoi(params[i]); }
-		else if(header[i] == "sched_use_expect_end_flag"){ sched_use_expect_end_flag = stoi(params[i]); }
-		else if(header[i] == "sched_progress_override"){ sched_progress_override = stoi(params[i]); }
-		else if(header[i] == "level_float_hrs_cnt"){ level_float_hrs_cnt = stoi(params[i]); }
-		else if(header[i] == "level_outer_assign_flag"){ level_outer_assign_flag = stoi(params[i]); }
-		else if(header[i] == "level_outer_assign_priority"){ level_outer_assign_priority = stoi(params[i]); }
-		else if(header[i] == "level_over_alloc_pct"){ level_over_alloc_pct = stoi(params[i]); }
-		else if(header[i] == "level_within_float_flag"){ level_within_float_flag = stoi(params[i]); }
-		else if(header[i] == "level_keep_sched_date_flag"){ level_keep_sched_date_flag = stoi(params[i]); }
-		else if(header[i] == "level_all_rsrc_flag"){ level_all_rsrc_flag = stoi(params[i]); }
-		else if(header[i] == "sched_use_project_end_date_for_float"){ sched_use_project_end_date_for_float = stoi(params[i]); }
-		else if(header[i] == "enable_multiple_longest_path_calc"){ enable_multiple_longest_path_calc = stoi(params[i]); }
-		else if(header[i] == "limit_multiple_longest_path_calc"){ limit_multiple_longest_path_calc = stoi(params[i]); }
-		else if(header[i] == "max_multiple_longest_path"){ max_multiple_longest_path = stoi(params[i]); }
-		else if(header[i] == "use_total_float_multiple_longest_paths"){ use_total_float_multiple_longest_paths = stoi(params[i]); }
-		else if(header[i] == "key_activity_for_multiple_longest_paths"){ key_activity_for_multiple_longest_paths = stoi(params[i]); }
-		else if(header[i] == "LevelPriorityList"){ LevelPriorityList = stoi(params[i]); }
+	for (int i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "schedoptions_id")
+		{
+			if (!params[i].empty())
+			{
+				schedoptions_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "proj_id")
+		{
+			if (!params[i].empty())
+			{
+				proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_outer_depend_type")
+		{
+			if (!params[i].empty())
+			{
+				sched_outer_depend_type = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_open_critical_flag")
+		{
+			if (!params[i].empty())
+			{
+				sched_open_critical_flag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_lag_early_start_flag")
+		{
+			if (!params[i].empty())
+			{
+				sched_lag_early_start_flag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_retained_logic")
+		{
+			if (!params[i].empty())
+			{
+				sched_retained_logic = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_setplantoforecast")
+		{
+			if (!params[i].empty())
+			{
+				sched_setplantoforecast = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_float_type")
+		{
+			if (!params[i].empty())
+			{
+				sched_float_type = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_calendar_on_relationship_lag")
+		{
+			if (!params[i].empty())
+			{
+				sched_calendar_on_relationship_lag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_use_expect_end_flag")
+		{
+			if (!params[i].empty())
+			{
+				sched_use_expect_end_flag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_progress_override")
+		{
+			if (!params[i].empty())
+			{
+				sched_progress_override = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "level_float_hrs_cnt")
+		{
+			if (!params[i].empty())
+			{
+				level_float_hrs_cnt = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "level_outer_assign_flag")
+		{
+			if (!params[i].empty())
+			{
+				level_outer_assign_flag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "level_outer_assign_priority")
+		{
+			if (!params[i].empty())
+			{
+				level_outer_assign_priority = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "level_over_alloc_pct")
+		{
+			if (!params[i].empty())
+			{
+				level_over_alloc_pct = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "level_within_float_flag")
+		{
+			if (!params[i].empty())
+			{
+				level_within_float_flag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "level_keep_sched_date_flag")
+		{
+			if (!params[i].empty())
+			{
+				level_keep_sched_date_flag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "level_all_rsrc_flag")
+		{
+			if (!params[i].empty())
+			{
+				level_all_rsrc_flag = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "sched_use_project_end_date_for_float")
+		{
+			if (!params[i].empty())
+			{
+				sched_use_project_end_date_for_float = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "enable_multiple_longest_path_calc")
+		{
+			if (!params[i].empty())
+			{
+				enable_multiple_longest_path_calc = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "limit_multiple_longest_path_calc")
+		{
+			if (!params[i].empty())
+			{
+				limit_multiple_longest_path_calc = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "max_multiple_longest_path")
+		{
+			if (!params[i].empty())
+			{
+				max_multiple_longest_path = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "use_total_float_multiple_longest_paths")
+		{
+			if (!params[i].empty())
+			{
+				use_total_float_multiple_longest_paths = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "key_activity_for_multiple_longest_paths")
+		{
+			if (!params[i].empty())
+			{
+				key_activity_for_multiple_longest_paths = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "LevelPriorityList")
+		{
+			if (!params[i].empty())
+			{
+				LevelPriorityList = stoi(params[i]);
+			}
+		}
 	}
-	tsv.append(std::to_string(schedoptions_id)).append("\t")
-	.append(std::to_string(proj_id)).append("\t")
-	.append(sched_outer_depend_type).append("\t")
-	.append(sched_open_critical_flag).append("\t")
-	.append(sched_lag_early_start_flag).append("\t")
-	.append(sched_retained_logic).append("\t")
-	.append(sched_setplantoforecast).append("\t")
-	.append(sched_float_type).append("\t")
-	.append(sched_calendar_on_relationship_lag).append("\t")
-	.append(sched_use_expect_end_flag).append("\t")
-	.append(sched_progress_override).append("\t")
-	.append(level_float_hrs_cnt).append("\t")
-	.append(level_outer_assign_flag).append("\t")
-	.append(level_outer_assign_priority).append("\t")
-	.append(level_over_alloc_pct).append("\t")
-	.append(level_within_float_flag).append("\t")
-	.append(level_keep_sched_date_flag).append("\t")
-	.append(level_all_rsrc_flag).append("\t")
-	.append(sched_use_project_end_date_for_float).append("\t")
-	.append(enable_multiple_longest_path_calc).append("\t")
-	.append(limit_multiple_longest_path_calc).append("\t")
-	.append(max_multiple_longest_path).append("\t")
-	.append(use_total_float_multiple_longest_paths).append("\t")
-	.append(key_activity_for_multiple_longest_paths).append("\t")
-	.append(LevelPriorityList).append("\n");
+	tsv.append(std::to_string(schedoptions_id)).append("\t").append(std::to_string(proj_id)).append("\t").append(sched_outer_depend_type).append("\t").append(sched_open_critical_flag).append("\t").append(sched_lag_early_start_flag).append("\t").append(sched_retained_logic).append("\t").append(sched_setplantoforecast).append("\t").append(sched_float_type).append("\t").append(sched_calendar_on_relationship_lag).append("\t").append(sched_use_expect_end_flag).append("\t").append(sched_progress_override).append("\t").append(level_float_hrs_cnt).append("\t").append(level_outer_assign_flag).append("\t").append(level_outer_assign_priority).append("\t").append(level_over_alloc_pct).append("\t").append(level_within_float_flag).append("\t").append(level_keep_sched_date_flag).append("\t").append(level_all_rsrc_flag).append("\t").append(sched_use_project_end_date_for_float).append("\t").append(enable_multiple_longest_path_calc).append("\t").append(limit_multiple_longest_path_calc).append("\t").append(max_multiple_longest_path).append("\t").append(use_total_float_multiple_longest_paths).append("\t").append(key_activity_for_multiple_longest_paths).append("\t").append(LevelPriorityList).append("\n");
 }

--- a/model/classes/TaskRsrc.cpp
+++ b/model/classes/TaskRsrc.cpp
@@ -7,20 +7,69 @@
 TaskRsrc::TaskRsrc(const std::string header[], const std::string params[]){
 	tsv = "";
 	for(uint i = 0; i < header->length(); i++){
-		if(header[i] == "taskrsrc_id"){ taskrsrc_id = stoi(params[i]); }
-		else if(header[i] == "task_id"){ task_id = stoi(params[i]); }
-		else if(header[i] == "proj_id"){ proj_id = params[i]; }
+		if(header[i] == "taskrsrc_id"){ 
+			if(!params[i].empty()){
+			taskrsrc_id = std::stoi(params[i]); 
+			}
+		}
+		else if(header[i] == "task_id"){ 
+			if(header[i] == "taskrsrc_id"){
+				task_id = std::stoi(params[i]); 
+				}
+		}
+		else if(header[i] == "proj_id"){
+			if(!params[i].empty()){ 
+			proj_id = std::stoi(params[i]); 
+			}
+		}
 		else if(header[i] == "cost_qty_link_flag"){ cost_qty_link_flag = params[i]; }
-		else if(header[i] == "role_id"){ role_id = params[i]; }
-		else if(header[i] == "acct_id"){ acct_id = params[i]; }
-		else if(header[i] == "rsrc_id"){ rsrc_id = stoi(params[i]); }
-		else if(header[i] == "pobs_id"){ pobs_id = params[i]; }
+		else if(header[i] == "role_id"){ 
+			if(!params[i].empty()){
+			role_id = std::stoi(params[i]); 
+			}
+		}
+		else if(header[i] == "acct_id"){ 
+			if(!params[i].empty()){
+				acct_id = std::stoi(params[i]); 
+			}
+		}
+		else if(header[i] == "rsrc_id"){ 
+			if(!params[i].empty()){
+				rsrc_id = std::stoi(params[i]); 
+			}
+		}
+		else if(header[i] == "pobs_id"){ 
+			if(!params[i].empty()){
+				pobs_id = std::stoi(params[i]); 
+				}
+			}
 		else if(header[i] == "skill_level"){ skill_level = params[i]; }
-		else if(header[i] == "remain_qty"){ remain_qty = stof(params[i]); }
-		else if(header[i] == "target_qty"){ target_qty = stof(params[i]); }
-		else if(header[i] == "remain_qty_per_hour"){ remain_qty_per_hour = stof(params[i]); }
-		else if(header[i] == "target_lag_drtn_hr_cnt"){ target_lag_drtn_hr_cnt = stof(params[i]); }
-		else if(header[i] == "target_qty_per_hour"){ target_qty_per_hour = stof(params[i]); }
+		else if(header[i] == "remain_qty"){ 
+			if(!params[i].empty()){
+				if(!params[i].empty()){
+					remain_qty = stof(params[i]);
+				} 
+			}
+		else if(header[i] == "target_qty"){ 
+			if(!params[i].empty()){
+				target_qty = stof(params[i]); 
+				}
+		}
+		else if(header[i] == "remain_qty_per_hour"){ 
+			if(!params[i].empty()){
+				remain_qty_per_hour = stof(params[i]); 
+				}
+		}
+		else if(header[i] == "target_lag_drtn_hr_cnt"){ 
+			if(!params[i].empty()){
+				target_lag_drtn_hr_cnt = stof(params[i]); 
+				}
+		}
+		else if(header[i] == "target_qty_per_hour"){ 
+			if(!params[i].empty()){
+				target_qty_per_hour = stof(params[i]); 
+			}
+		}
 		else if(header[i] == "act_ot_qty"){ act_ot_qty = params[i]; }
 		else if(header[i] == "act_reg_qty"){ act_reg_qty = params[i]; }
 		else if(header[i] == "relag_drtn_hr_cnt"){ relag_drtn_hr_cnt = params[i]; }
@@ -56,14 +105,15 @@ TaskRsrc::TaskRsrc(const std::string header[], const std::string params[]){
 		else if(header[i] == "has_rsrchours"){ has_rsrchours = params[i]; }
 		else if(header[i] == "taskrsrc_sum_id"){ taskrsrc_sum_id = params[i]; }
 	}
+	}
 	tsv.append(std::to_string(taskrsrc_id)).append("\t")
 	.append(std::to_string(task_id)).append("\t")
-	.append(proj_id).append("\t")
+	.append(std::to_string(proj_id)).append("\t")
 	.append(cost_qty_link_flag).append("\t")
-	.append(role_id).append("\t")
-	.append(acct_id).append("\t")
+	.append(std::to_string(role_id)).append("\t")
+	.append(std::to_string(acct_id)).append("\t")
 	.append(std::to_string(rsrc_id)).append("\t")
-	.append(pobs_id).append("\t")
+	.append(std::to_string(pobs_id)).append("\t")
 	.append(skill_level).append("\t")
 	.append(std::to_string(remain_qty)).append("\t")
 	.append(std::to_string(target_qty)).append("\t")

--- a/model/classes/TaskRsrc.h
+++ b/model/classes/TaskRsrc.h
@@ -12,12 +12,12 @@ class TaskRsrc{
 public:
 		int taskrsrc_id;
 		int task_id;
-		std::string proj_id;
+		int proj_id;
 		std::string cost_qty_link_flag;
-		std::string role_id;
-		std::string acct_id;
+		int role_id;
+		int acct_id;
 		int rsrc_id;
-		std::string pobs_id;
+		int pobs_id;
 		std::string skill_level;
 		float remain_qty;
 		float target_qty;

--- a/model/classes/Taskactv.cpp
+++ b/model/classes/Taskactv.cpp
@@ -4,17 +4,47 @@
 
 #include "Taskactv.h"
 
-Taskactv::Taskactv(const std::string *header, const std::string *params){
+Taskactv::Taskactv(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "task_id"){ task_id = stoi(params[i]); }
-		else if(header[i] == "actv_code_type_id"){ actv_code_type_id = stoi(params[i]); }
-		else if(header[i] == "actv_code_id"){ actv_code_id = stoi(params[i]); }
-		else if(header[i] == "proj_id"){ proj_id = stoi(params[i]); }
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "task_id")
+		{
+			if (!params[i].empty())
+			{
+				task_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "actv_code_type_id")
+		{
+			if (!params[i].empty())
+			{
+				actv_code_type_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "actv_code_id")
+		{
+			if (!params[i].empty())
+			{
+				actv_code_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "proj_id")
+		{
+			if (!params[i].empty())
+			{
+				proj_id = stoi(params[i]);
+			}
+		}
 	}
 	tsv
-	.append(std::to_string(task_id)).append("\t")
-	.append(std::to_string(actv_code_type_id)).append("\t")
-	.append(std::to_string(actv_code_id)).append("\t")
-	.append(std::to_string(proj_id)).append("\n");
+		.append(std::to_string(task_id))
+		.append("\t")
+		.append(std::to_string(actv_code_type_id))
+		.append("\t")
+		.append(std::to_string(actv_code_id))
+		.append("\t")
+		.append(std::to_string(proj_id))
+		.append("\n");
 }

--- a/model/classes/Taskpred.cpp
+++ b/model/classes/Taskpred.cpp
@@ -4,30 +4,70 @@
 
 #include "Taskpred.h"
 
-Taskpred::Taskpred(const std::string *header, const std::string *params){
+Taskpred::Taskpred(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->size(); i++){
-		if(header[i] == "task_pred_id"){ task_pred_id = stoi(params[i]); }
-		else if(header[i] == "task_id"){ task_id = stoi(params[i]); }
-		else if(header[i] == "pred_task_id"){ pred_task_id = stoi(params[i]); }
-		else if(header[i] == "proj_id"){ proj_id = stoi(params[i]); }
-		else if(header[i] == "pred_proj_id"){ pred_proj_id = stoi(params[i]); }
-		else if(header[i] == "pred_type"){ pred_type = params[i]; }
-		else if(header[i] == "lag_hr_cnt"){ lag_hr_cnt = params[i]; }
-		else if(header[i] == "comments"){ comments = params[i]; }
-		else if(header[i] == "float_path"){ float_path = params[i]; }
-		else if(header[i] == "aref"){ aref = params[i]; }
-		else if(header[i] == "arls"){ arls = params[i]; }
+	for (uint i = 0; i < params->size(); i++)
+	{
+		if (header[i] == "task_pred_id")
+		{
+			if (!params[i].empty())
+			{
+				task_pred_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "task_id")
+		{
+			if (!params[i].empty())
+			{
+				task_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "pred_task_id")
+		{
+			if (!params[i].empty())
+			{
+				pred_task_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "proj_id")
+		{
+			if (!params[i].empty())
+			{
+				proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "pred_proj_id")
+		{
+			if (!params[i].empty())
+			{
+				pred_proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "pred_type")
+		{
+			pred_type = params[i];
+		}
+		else if (header[i] == "lag_hr_cnt")
+		{
+			lag_hr_cnt = params[i];
+		}
+		else if (header[i] == "comments")
+		{
+			comments = params[i];
+		}
+		else if (header[i] == "float_path")
+		{
+			float_path = params[i];
+		}
+		else if (header[i] == "aref")
+		{
+			aref = params[i];
+		}
+		else if (header[i] == "arls")
+		{
+			arls = params[i];
+		}
 	}
-	tsv.append(std::to_string(task_pred_id)).append("\t")
-	.append(std::to_string(task_id)).append("\t")
-	.append(std::to_string(pred_task_id)).append("\t")
-	.append(std::to_string(proj_id)).append("\t")
-	.append(std::to_string(pred_proj_id)).append("\t")
-	.append(pred_type).append("\t")
-	.append(lag_hr_cnt).append("\t")
-	.append(comments).append("\t")
-	.append(float_path).append("\t")
-	.append(aref).append("\t")
-	.append(arls).append("\n");
+	tsv.append(std::to_string(task_pred_id)).append("\t").append(std::to_string(task_id)).append("\t").append(std::to_string(pred_task_id)).append("\t").append(std::to_string(proj_id)).append("\t").append(std::to_string(pred_proj_id)).append("\t").append(pred_type).append("\t").append(lag_hr_cnt).append("\t").append(comments).append("\t").append(float_path).append("\t").append(aref).append("\t").append(arls).append("\n");
 }

--- a/model/classes/Taskproc.cpp
+++ b/model/classes/Taskproc.cpp
@@ -4,27 +4,77 @@
 
 #include "Taskproc.h"
 
-Taskproc::Taskproc(const std::string *header, const std::string *params){
+Taskproc::Taskproc(const std::string *header, const std::string *params)
+{
 	tsv = "";
-	for(uint i = 0; i < params->length(); i++){
-		if(header[i] == "proc_id"){ proc_id = stoi(params[i]);}
-		else if(header[i] == "task_id"){ task_id = stoi(params[i]);}
-		else if(header[i] == "proj_id"){ proj_id = stoi(params[i]);}
-		else if(header[i] == "seq_num"){ seq_num = stoi(params[i]);}
-		else if(header[i] == "proc_name"){ proc_name = params[i];}
-		else if(header[i] == "complete_flag"){ complete_flag = params[i];}
-		else if(header[i] == "proc_wt"){ proc_wt = params[i];}
-		else if(header[i] == "complete_pct"){ complete_pct = params[i];}
-		else if(header[i] == "proc_descr"){ proc_descr = params[i];}
+	for (uint i = 0; i < params->length(); i++)
+	{
+		if (header[i] == "proc_id")
+		{
+			if (!params[i].empty())
+			{
+				proc_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "task_id")
+		{
+			if (!params[i].empty())
+			{
+				task_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "proj_id")
+		{
+			if (!params[i].empty())
+			{
+				proj_id = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "seq_num")
+		{
+			if (!params[i].empty())
+			{
+				seq_num = stoi(params[i]);
+			}
+		}
+		else if (header[i] == "proc_name")
+		{
+			proc_name = params[i];
+		}
+		else if (header[i] == "complete_flag")
+		{
+			complete_flag = params[i];
+		}
+		else if (header[i] == "proc_wt")
+		{
+			proc_wt = params[i];
+		}
+		else if (header[i] == "complete_pct")
+		{
+			complete_pct = params[i];
+		}
+		else if (header[i] == "proc_descr")
+		{
+			proc_descr = params[i];
+		}
 	}
 	tsv
-	.append(std::to_string(proc_id)).append("\t")
-	.append(std::to_string(task_id)).append("\t")
-	.append(std::to_string(proj_id)).append("\t")
-	.append(std::to_string(seq_num)).append("\t")
-	.append(proc_name).append("\t")
-	.append(complete_flag).append("\t")
-	.append(proc_wt).append("\t")
-	.append(complete_pct).append("\t")
-	.append(proc_descr).append("\n");
+		.append(std::to_string(proc_id))
+		.append("\t")
+		.append(std::to_string(task_id))
+		.append("\t")
+		.append(std::to_string(proj_id))
+		.append("\t")
+		.append(std::to_string(seq_num))
+		.append("\t")
+		.append(proc_name)
+		.append("\t")
+		.append(complete_flag)
+		.append("\t")
+		.append(proc_wt)
+		.append("\t")
+		.append(complete_pct)
+		.append("\t")
+		.append(proc_descr)
+		.append("\n");
 }

--- a/sample.xer
+++ b/sample.xer
@@ -1,16 +1,17 @@
+ERMHDR	8.2	2013-09-18	Project	admin	admin	dbxDatabaseNoName	Project Management	EP
 %T	CURRTYPE
 %F	curr_id	decimal_digit_cnt	curr_symbol	decimal_symbol	digit_group_symbol	pos_curr_fmt_type	neg_curr_fmt_type	curr_type	curr_short_name	group_digit_cnt	base_exch_rate
-%R	1	2	£	.	,	#1.1	(#1.1)	British Pound	U.K.	3	1
+%R	1	2	ï¿½	.	,	#1.1	(#1.1)	British Pound	U.K.	3	1
 %R	10	2	$	.	,	#1.1	(#1.1)	Argentine Peso	ARS	3	6.132389
 %R	11	2	A$	.	,	#1.1	(#1.1)	Australian Dollar	AUST	3	2.407516
 %R	13	2	R$	.	,	#1.1	(#1.1)	Brazilian Real	BRL	3	4.013855
 %R	14	2	$	.	,	#1.1	(#1.1)	Dollar	USD	3	1.992977
 %R	15	2	CA$	.	,	#1.1	(#1.1)	Canadian Dollar	CAD	3	2.203694
 %R	16	2	Y	.	,	#1.1	(#1.1)	Chinese Yuan	CNY	3	15.333963
-%R	17	2	€	.	,	#1.1	(#1.1)	EURO	EUR	3	1.472985
+%R	17	2	ï¿½	.	,	#1.1	(#1.1)	EURO	EUR	3	1.472985
 %R	20	2	HK$	.	,	#1.1	(#1.1)	Hong Kong Dollar	HKD	3	15.584421
 %R	21	2	Rs	.	,	#1.1	(#1.1)	Indian Rupee	INR	3	81.054364
-%R	23	2	¥	.	,	#1.1	(#1.1)	Japanese Yen	JPY	3	239.490037
+%R	23	2	ï¿½	.	,	#1.1	(#1.1)	Japanese Yen	JPY	3	239.490037
 %R	24	2	K	.	,	#1.1	(#1.1)	Korean Won	KRW	3	1842.991299
 %R	25	2	N$	.	,	#1.1	(#1.1)	Mexican Peso	MXN	3	21.511792
 %R	26	2	R	.	,	#1.1	(#1.1)	Russian Rouble	RUB	3	51.43574

--- a/wk2.xer
+++ b/wk2.xer
@@ -1,0 +1,2161 @@
+ERMHDR	8.2	2013-09-18	Project	admin	admin	dbxDatabaseNoName	Project Management	EP
+%T	COSTTYPE
+%F	cost_type_id	seq_num	cost_type
+%R	4	50000	Materials
+%T	CURRTYPE
+%F	curr_id	decimal_digit_cnt	curr_symbol	decimal_symbol	digit_group_symbol	pos_curr_fmt_type	neg_curr_fmt_type	curr_type	curr_short_name	group_digit_cnt	base_exch_rate
+%R	1	2	$	.	,	#1.1	(#1.1)	US Dollar	USD	3	1
+%R	13	2	£	.	,	#1.1	(#1.1)	Pound Sterling	GBP	3	0.618603
+%R	14	2	¥	.	,	#1.1	(#1.1)	Japanese Yen	JPY	3	91.2708
+%R	15	2	€	.	,	#1.1	(#1.1)	Euro	EUR	3	0.689711
+%R	16	2	¥	.	,	#1.1	(#1.1)	Chinese Yuan Renminbi	CNY	3	6.82502
+%R	17	2	$	.	,	#1.1	(#1.1)	Canadian Dollar	CAD	3	1.03757
+%R	18	2	RUB	.	,	#1.1	(#1.1)	Russian Ruble	RUB	3	0.033948
+%R	19	2	$	.	,	#1.1	(#1.1)	Argentine Peso	ARS	3	3.79109
+%R	20	2	$b	.	,	#1.1	(#1.1)	Bolivian Boliviano	BOB	3	7.5708
+%R	21	2	R$	.	,	#1.1	(#1.1)	Brazilian Real	BRL	3	1.7665
+%R	22	2	$	.	,	#1.1	(#1.1)	Chilean Peso	CLP	3	507.58
+%R	23	2	$	.	,	#1.1	(#1.1)	Columbian Peso	COP	3	1957.74
+%R	24	2	$	.	,	#1.1	(#1.1)	Guyanese Dollar	GYD	3	202.95
+%R	25	2	Gs	.	,	#1.1	(#1.1)	Paraguayan Guarani	PYG	3	4640
+%R	26	2	S/.	.	,	#1.1	(#1.1)	Peruvian Nuevo Sol	PEN	3	2.7244
+%R	27	2	$	.	,	#1.1	(#1.1)	Surinamese Dollar	SRD	3	2.8
+%R	28	2	Bs	.	,	#1.1	(#1.1)	Venezuelan Bolivar Fuerto	VEF	3	2.1446
+%R	29	2	$U	.	,	#1.1	(#1.1)	Uruguayan Peso	UYU	3	21.247
+%R	30	2	LE	.	,	#1.1	(#1.1)	EGP	EP	3	6.97
+%T	OBS
+%F	obs_id	parent_obs_id	guid	seq_num	obs_name	obs_descr
+%R	540			0	Enterprise	<html>  <head>      </head>  <body bgcolor=""#ffffff"">    Enterprise  </body></html>
+%T	POBS
+%F	pobs_id	pobs_parent_id	seq_num	pobs_name	pobs_descr	pobs_manager
+%R	100		0	POBS_Root	Performing Organization_Root	
+%R	101	100	0	P	Performing Organization	
+%R	102	100	100	P-1	Performing Organization	
+%R	103	100	200	P-2	Performing Organization	
+%R	104	100	300	P-3	Performing Organization	
+%R	105	100	400	P-4	Performing Organization	
+%R	106	100	500	P-5	Performing Organization	
+%R	107	100	600	P-6	Performing Organization	
+%R	108	100	0	?><,./;'[]\=-`	?><,./;'[]\=-`	?><,./;'[]\=-`
+%T	RCATTYPE
+%F	rsrc_catg_type_id	seq_num	rsrc_catg_short_len	rsrc_catg_type
+%R	112	0	7	equipment
+%R	113	100	7	labour
+%R	114	200	7	material
+%T	UMEASURE
+%F	unit_id	seq_num	unit_abbrev	unit_name
+%R	104	100	tons	Tons
+%R	213	0	m3	meter cubic
+%R	215	5	TH	1000
+%R	216	4	m2	squre meter
+%R	217	3	kg	kilogram
+%R	218	2	UT	UNIT
+%T	RCATVAL
+%F	rsrc_catg_id	rsrc_catg_type_id	seq_num	rsrc_catg_short_name	rsrc_catg_name	parent_rsrc_catg_id
+%R	778	112	0	01	heavy equpiment	
+%R	779	112	100	02	light equipment	
+%R	782	113	100	02	concrete labour	
+%R	784	114	0	01	rough material	
+%T	PROJECT
+%F	proj_id	fy_start_month_num	rsrc_self_add_flag	allow_complete_flag	rsrc_multi_assign_flag	checkout_flag	project_flag	step_complete_flag	cost_qty_recalc_flag	batch_sum_flag	name_sep_char	def_complete_pct_type	proj_short_name	acct_id	orig_proj_id	source_proj_id	base_type_id	clndr_id	sum_base_proj_id	task_code_base	task_code_step	priority_num	wbs_max_sum_level	strgy_priority_num	last_checksum	critical_drtn_hr_cnt	def_cost_per_qty	last_recalc_date	plan_start_date	plan_end_date	scd_end_date	add_date	last_tasksum_date	fcst_start_date	def_duration_type	task_code_prefix	guid	def_qty_type	add_by_name	web_local_root_path	proj_url	def_rate_type	add_act_remain_flag	act_this_per_link_flag	def_task_type	act_pct_link_flag	critical_path_type	task_code_prefix_flag	def_rollup_dates_flag	use_project_baseline_flag	rem_target_link_flag	reset_planned_flag	allow_neg_act_flag	sum_assign_level	last_fin_dates_id	last_baseline_update_date	cr_external_key	apply_actuals_date	location_id	loaded_scope_level	export_flag	new_fin_dates_id	next_data_date	close_period_flag	sum_refresh_date	trsrcsum_loaded
+%R	4680	1	Y	Y	Y	N	Y	N	N	Y	.	CP_Drtn	TP					6690	5014	1000	10	10	2	500		0	0.00	2013-08-03 00:00	2013-08-03 00:00		2015-02-19 12:00	2013-08-03 00:00			DT_FixedDUR2	A	r8xWHu550UqBuuAQnWs8dQ	QT_Hour	admin			COST_PER_QTY	N	Y	TT_Task	Y	CT_TotFloat	Y	Y	Y	Y	N	N	SL_Taskrsrc						7	Y				1899-12-30 00:00	
+%T	CALENDAR
+%F	clndr_id	default_flag	clndr_name	proj_id	base_clndr_id	last_chng_date	clndr_type	day_hr_cnt	week_hr_cnt	month_hr_cnt	year_hr_cnt	rsrc_private	clndr_data
+%R	6690	Y	test project			2013-06-18 00:00	CA_Base	10	50	300	3650	N	(0||CalendarData()(  (0||DaysOfWeek()(    (0||1()(      (0||0(s|08:00|f|16:00)())))    (0||2()(      (0||0(s|08:00|f|16:00)())))    (0||3()(      (0||0(s|08:00|f|16:00)())))    (0||4()(      (0||0(s|08:00|f|16:00)())))    (0||5()(      (0||0(s|08:00|f|16:00)())))    (0||6()())    (0||7()(      (0||0(s|08:00|f|16:00)())))))  (0||VIEW(ShowTotal|Y)())  (0||Exceptions()(    (0||0(d|36897)())    (0||1(d|36898)())    (0||2(d|36904)())    (0||3(d|36905)())    (0||4(d|36911)())    (0||5(d|36912)())    (0||6(d|36918)())    (0||7(d|36919)())    (0||8(d|36925)())    (0||9(d|36926)())    (0||10(d|36932)())    (0||11(d|36933)())    (0||12(d|36939)())    (0||13(d|36940)())    (0||14(d|36946)())    (0||15(d|36947)())    (0||16(d|36953)())    (0||17(d|36954)())    (0||18(d|36960)())    (0||19(d|36961)())    (0||20(d|36967)())    (0||21(d|36968)())    (0||22(d|36974)())    (0||23(d|36975)())    (0||24(d|36981)())    (0||25(d|36982)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||26(d|36983)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||27(d|36984)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||28(d|36985)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||29(d|36986)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||30(d|36987)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||31(d|36988)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||32(d|36989)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||33(d|36990)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||34(d|36991)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||35(d|36992)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||36(d|36993)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||37(d|36994)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||38(d|36995)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||39(d|36996)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||40(d|36997)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||41(d|36998)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||42(d|36999)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||43(d|37000)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||44(d|37001)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||45(d|37002)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||46(d|37003)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||47(d|37004)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||48(d|37005)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||49(d|37006)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||50(d|37007)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||51(d|37008)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||52(d|37009)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||53(d|37010)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||54(d|37011)(      (0||0(s|08:00|f|12:00)())      (0||1(s|13:00|f|17:00)())))    (0||55(d|40179)())    (0||56(d|40329)())    (0||57(d|40364)())    (0||58(d|40427)())    (0||59(d|40507)())    (0||60(d|40536)())    (0||61(d|40543)())    (0||62(d|40693)())    (0||63(d|40728)())    (0||64(d|40791)())    (0||65(d|40871)())    (0||66(d|40903)())    (0||67(d|40910)())    (0||68(d|41057)())    (0||69(d|41094)())    (0||70(d|41155)())    (0||71(d|41235)())    (0||72(d|41268)())    (0||73(d|41275)())    (0||74(d|41421)())    (0||75(d|41459)())    (0||76(d|41519)())    (0||77(d|41606)())    (0||78(d|41633)())))))
+%T	SCHEDOPTIONS
+%F	schedoptions_id	proj_id	sched_outer_depend_type	sched_open_critical_flag	sched_lag_early_start_flag	sched_retained_logic	sched_setplantoforecast	sched_float_type	sched_calendar_on_relationship_lag	sched_use_expect_end_flag	sched_progress_override	level_float_thrs_cnt	level_outer_assign_flag	level_outer_assign_priority	level_over_alloc_pct	level_within_float_flag	level_keep_sched_date_flag	level_all_rsrc_flag	sched_use_project_end_date_for_float	enable_multiple_longest_path_calc	limit_multiple_longest_path_calc	max_multiple_longest_path	use_total_float_multiple_longest_paths	key_activity_for_multiple_longest_paths	LevelPriorityList
+%R	1	4680	SD_Both	N	Y	Y	N	FT_FF	rcal_Predecessor	Y	N	0	N	5	25	N	Y	Y	Y	N	Y	10	Y		priority_type,ASC
+%T	PROJWBS
+%F	wbs_id	proj_id	obs_id	seq_num	proj_node_flag	sum_data_flag	status_code	wbs_short_name	wbs_name	phase_id	parent_wbs_id	ev_user_pct	ev_etc_user_value	orig_cost	indep_remain_total_cost	ann_dscnt_rate_pct	dscnt_period_type	indep_remain_work_qty	anticip_start_date	anticip_end_date	ev_compute_type	ev_etc_compute_type	guid	tmpl_guid	plan_open_state
+%R	26186	4680	540	400	Y	N	WS_Open	TP	TRIAL PROJECT		3063	6	0.88	0.00	0.00						EC_Cmp_pct	EE_Rem_hr	sbapS36S5kSlZZdCYbDROQ		
+%T	RSRC
+%F	rsrc_id	parent_rsrc_id	clndr_id	role_id	shift_id	user_id	pobs_id	guid	rsrc_seq_num	email_addr	employee_code	office_phone	other_phone	rsrc_name	rsrc_short_name	rsrc_title_name	def_qty_per_hr	cost_qty_type	ot_factor	active_flag	auto_compute_act_flag	def_cost_qty_link_flag	ot_flag	curr_id	unit_id	rsrc_type	location_id	rsrc_notes	load_tasks_flag	level_flag	last_checksum
+%R	10552	9977	6690					vai9WS2H+UKq4+31aEcffA	100					excavator	E01		0.8	QT_Hour		Y	Y	Y	N	30		RT_Equip					
+%R	10553	9977	6690					vfufwoihwEysw61Szptm8A	200					lodr	E02		0.8	QT_Hour		Y	Y	Y	N	30		RT_Equip					
+%R	10554	9977	6690					qx+Uhhibo0axq1gtPLUY5g	300					truck	E03		0.8	QT_Hour		Y	Y	Y	N	30		RT_Equip					
+%R	10555	9977	6690					3zlGhA60ckeSQmdlsPZF+Q	400					compactor	E04		0.8	QT_Hour		Y	Y	Y	N	30		RT_Equip					
+%R	10557	9977	6690					2HYvxhf/2Eu9MDBbQ5E5gQ	600					CARPENTER	L01		0.8	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10558	9977	6690					ZpJ8VEUNgky6hB8FJeijlg	700					STELL FIXER	L02		0.8	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10559	9977	6690					AS9IUiwLv0udi5D90FMpXA	1014					STEEL	M01		1	QT_Hour	0	Y	Y	Y	N	30	104	RT_Mat					
+%R	10560	9977	6690					Yzfjvvl6a0qBDVM1NxGlXQ	1100					CONCRETE	M02		1	QT_Hour		Y	Y	N	N	30	213	RT_Mat					
+%R	10562	9977	6690					C/0uQdT7Z0yG1HMUFRYZ2A	900					LABOUR	L04		0.8	QT_Hour	0	Y	Y	Y	N	30		RT_Labor					
+%R	10563	9977	6690					71TL71bPZkWsT+SK6xKmIQ	1201					BRICK	M04		1	QT_Hour	0	Y	Y	Y	N	30	215	RT_Mat					
+%R	10564	9977	6690					ydkBrEe2ekmy0xBQMNMAuw	800					MAISON	L03		0.8	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10565	9977	6690					W0/385KlsEm36vV6Kf0yJw	1301					ISOLATION	M05		1	QT_Hour		Y	Y	Y	N	30	217	RT_Mat					
+%R	10566	9977	6690					e9nRPJEkxEi9Z8OcPYolrA	1000					REPLACEMENT	L05		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10567	9977	6690					45gos3GvZU2yjcozTtbUNg	1401					WATER	M06		1	QT_Hour		Y	Y	Y	N	30	213	RT_Mat					
+%R	10568	9977	6690					lV8TyM1w+0+69PeVPaMjwA	1402					CEMENT	M07		1	QT_Hour		Y	Y	Y	N	30	104	RT_Mat					
+%R	10569	9977	6690					5cODYQANiUm4hRGvB5J0Ng	1501					INSOMAT	M08		1	QT_Hour		Y	Y	Y	N	30	216	RT_Mat					
+%R	10570	9977	6690					ViBVrlbkSkSodCKHZFzYhQ	1601					SAND	M09		0.8	QT_Hour		Y	Y	Y	N	30	213	RT_Mat					
+%R	10571	9977	6690					aM8KeynAl0W5Cq9vkYf+AA	1701					WOODEN FRAME	M10		1	QT_Hour		Y	Y	Y	N	30	218	RT_Mat					
+%R	10572	9977	6690					0G7OAxBozECv9Knglh6IFg	1001					PLASTER	L06		1	QT_Hour		Y	Y	N	N	30		RT_Labor		<HTML><HEAD><META NAME=""GENERATOR"" Content=""Microsoft DHTML Editing Control""><TITLE></TITLE></HEAD><BODY><P>BASEMENT FLOOR 8LE</P><P>CELLING 10LE</P><P>GROUND FLOOR 9 LE</P><P>CELLING 11</P><P>&nbsp;</P></BODY></HTML>			
+%R	10573	9977	6690					HnqxI8x4nUKSEVLCVjh03Q	1002					PACKING LABOUR	L07		1	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10574	9977	6690					9p16d8ypJEyPMExewQa7kg	1003					CERMIC MAISON	L08		1	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10575	9977	6690					+w+CgQSdbEaHqoyF2qdMYQ	1801					CERMIC	M11		1	QT_Hour		Y	Y	N	N	30	216	RT_Mat					
+%R	10576	9977	6690					BcMkqQuTNUqNYSa7V58ksA	1901					WHITE CEMENT	M12		1	QT_Hour		Y	Y	Y	N	30	104	RT_Mat					
+%R	10577	9977	6690					ik2Ly9BAFEKHnI83g6p4nw	1004					PAINTER	L09		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10578	9977	6690					U/9CrLVVk0qRsbWKHeenaw	2001					PAINT PACKAGE	M13		1	QT_Hour		Y	Y	Y	N	30	218	RT_Mat					
+%R	10579	9977	6690					k1/Sb6FZ0EabuLSHPyiGCA	1005					FALSE CELLING	L10		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10580	9977	6690					CXRseweaNkCWJRBlgXtVSA	1006					STEEL MAKER	L11		1	QT_Hour	0	Y	Y	Y	N	30	217	RT_Mat					
+%R	10581	9977	6690					1OSNSqsDEkC7UXxcMbRhzA	2101					RED TILE	M14		1	QT_Hour		Y	Y	Y	N	30	216	RT_Mat					
+%R	10582	9977	6690					YbDBtaoMEkuxNVs92eRopg	1007					TILE MAISON	L12		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10583	9977	6690					9CeqbTOGT0O2dtQEER2ltg	1008					ISOLATION LABOUR	L13		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10584	9977	6690					XdI8WPyFSEWvR2hb3f/T2A	2201					THERMAL ISOLATION	M15		1	QT_Hour		Y	Y	Y	N	30	216	RT_Mat					
+%R	10585	9977	6690					fBLo/mn8LkO4yWJjUTUVeg	2301					WINDOWS&DOORS	M16		1	QT_Hour		Y	Y	Y	N	30	218	RT_Mat					
+%R	10586	9977	6690					gUVV0kkyGkOLmEXIsV6OyQ	2401					WOODEN FLOOR	M17		1	QT_Hour		Y	Y	Y	N	30	216	RT_Mat					
+%R	10587	9977	6690					zfTX5hgEy0ahVey+5C+EUw	2501					MARBLE	M18		1	QT_Hour		Y	Y	Y	N	30	216	RT_Mat					
+%R	10588	9977	6690					ajoYfPHA5U6gWlaY7NeZ5Q	1009					FINISHING LABOUR	L14		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10589	9977	6690					oVyiIWnoK06uuamTipgryA	2601					ALMNIUM	M19		1	QT_Hour		Y	Y	Y	N	30	216	RT_Mat					
+%R	10590	9977	6690					FB2PLUz+GEO+qde9qXcgUA	2701					CEMENT TILE	M20		1	QT_Hour		Y	Y	Y	N	30	216	RT_Mat					
+%R	10592	9977	6690					d3JVAtM/TE2D1lh50T0KNQ	2801					GRAVITO	M21		1	QT_Hour		Y	Y	Y	N	30	104	RT_Mat					
+%R	10593	9977	6690					j7wzkpmN/0WdA0cRaY+rtw	1010					STAIRS	L15		1	QT_Hour	0	Y	Y	Y	N	30	218	RT_Mat					
+%R	10594	9977	6690					DwUJeRi7GUSIGtFYcMUhFA	1011					FURNTURE	L16		1	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10595	9977	6690					9qx+TMWG50KBNlem3jR9Aw	2901					SAINTARY material	M22		1	QT_Hour		Y	Y	N	N	30	218	RT_Mat					
+%R	10596	9977	6690					RrbXJORCNUmsSDb5ZnKEwA	1012					PLUMPER	L17		1	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10597	9977	6690					ZrpkYqFnu0WmrgK/l510Gg	3001					BOX & PIPE	M23		1	QT_Hour	0	Y	Y	N	N	30	218	RT_Mat					
+%R	10598	9977	6690					pMRppmqeb0ajKGsyMl4Hsw	3101					ELEC WIRE	M24		1	QT_Hour		Y	Y	N	N	30		RT_Mat					
+%R	10599	9977	6690					Upz8kvK8lUW0TNFMx3/ZTw	3201					FINISHING ELEC	M25		1	QT_Hour		Y	Y	Y	N	30		RT_Mat					
+%R	10600	9977	6690					AP1DrfeXy0aPB00LU9D5Ng	1013					ELECTRICAL	L18		1	QT_Hour		Y	Y	N	N	30		RT_Labor					
+%R	10602	9977	6690					zmpm7Z2lAkSAS+UeK4g5Og	3401					CARPENTER	LB2		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10603	9977	6690					9oLeQveJsE23B3tRqdh9zw	3301					LABOUR	LB1		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10604	9977	6690					2qXZNEfnike9SfNsFlMJlw	3501					STEEL FIXER	LB3		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10605	9977	6690					62/vk9ctwk2mb88etHZ2cA	3601					MASION	LB4		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10606	9977	6690					RCvZuBBrDk2fQhOoerDajw	3701					ISOLATION	LB5		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10607	9977	6690					EoK+w87wUUOPItj1SvzLow	3801					PLASTER	LB6		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10608	9977	6690					Pa1STf+7pkuvkPGuFrObWg	3901					TILE MASION	LB7		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10609	9977	6690					LRaFH1TvCUaqskj6j8dGWw	4001					FALSE CEILLING	LB8		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10610	9977	6690					y9n+oWhCnkydqy7tJis7KA	4101					PAINTER	LB9		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10611	9977	6690					8u+wSs2sY0+084DUv4/xmA	4201					PLUMPER	LB10		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10612	9977	6690					m9CU+MdS5028RynJl3R3Mg	4301					ELECTRCIAN	LB11		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	10614	9977	6690					jyySdJ0rL064Boja2DFn/A	4401					MARBLE MAISON	LB12		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%R	9977		6690					FIOvg+seKUyCbxDtXDryJQ	0					TEST PROJECT	TP		1	QT_Hour		Y	Y	Y	N	30		RT_Labor					
+%T	ACTVTYPE
+%F	actv_code_type_id	actv_short_len	seq_num	actv_code_type	proj_id	wbs_id	actv_code_type_scope
+%R	1734	7	0	01 project	4680		AS_Project
+%R	1735	7	100	02 type of work	4680		AS_Project
+%R	1736	7	200	03 div of work	4680		AS_Project
+%R	1737	7	300	04 floor	4680		AS_Project
+%T	RSRCRATE
+%F	rsrc_rate_id	rsrc_id	max_qty_per_hr	cost_per_qty	start_date	shift_period_id	cost_per_qty2	cost_per_qty3	cost_per_qty4	cost_per_qty5
+%R	7331	10552	1	30.00	2013-01-01 00:00					
+%R	7332	10553	1	20.00	2013-01-01 00:00					
+%R	7333	10554	1	15.00	2013-01-01 00:00					
+%R	7334	10555	1	5.00	2013-01-01 00:00					
+%R	7336	10557	1	0.00	2013-01-01 00:00					
+%R	7337	10558	1	0.00	2013-01-01 00:00					
+%R	7338	10559	1	5000.00	2013-01-01 00:00					
+%R	7339	10560	1	0.00	2013-01-01 00:00					
+%R	7341	10562	1	0.00	2013-01-01 00:00					
+%R	7342	10563	1	250.00	2013-01-01 00:00					
+%R	7343	10564	1	0.00	2013-01-01 00:00					
+%R	7344	10565	1	3.00	2013-01-01 00:00					
+%R	7345	10566	1	13.00	2013-01-01 00:00					
+%R	7346	10567	1	2.00	2013-01-01 00:00					
+%R	7347	10568	1	500.00	2013-01-01 00:00					
+%R	7348	10569	1	25.00	2013-01-01 00:00					
+%R	7349	10570	1	12.00	2013-01-01 00:00					
+%R	7350	10571	1	200.00	2013-01-01 00:00					
+%R	7351	10572	1	0.00	2013-01-01 00:00					
+%R	7352	10573	1	0.00	2013-01-01 00:00					
+%R	7353	10574	1	0.00	2013-01-01 00:00					
+%R	7354	10575	1	0.00	2013-01-01 00:00					
+%R	7355	10576	1	750.00	2013-01-01 00:00					
+%R	7356	10577	1	12.00	2013-01-01 00:00					
+%R	7357	10578	1	50.00	2013-01-01 00:00					
+%R	7358	10579	1	120.00	2013-01-01 00:00					
+%R	7359	10580	1	12.00	2013-01-01 00:00					
+%R	7360	10581	1	90.00	2013-01-01 00:00					
+%R	7361	10582	1	35.00	2013-01-01 00:00					
+%R	7362	10583	1	10.00	2013-01-01 00:00					
+%R	7363	10584	1	50.00	2013-01-01 00:00					
+%R	7364	10585	1	150.00	2013-01-01 00:00					
+%R	7365	10586	1	15.00	2013-01-01 00:00					
+%R	7366	10587	1	80.00	2013-01-01 00:00					
+%R	7367	10588	1	3.00	2013-01-01 00:00					
+%R	7368	10589	1	150.00	2013-01-01 00:00					
+%R	7369	10590	1	12.00	2013-01-01 00:00					
+%R	7371	10592	1	1000.00	2013-01-01 00:00					
+%R	7372	10593	1	50.00	2013-01-01 00:00					
+%R	7373	10594	1	0.00	2013-01-01 00:00					
+%R	7374	10595	1	0.00	2013-01-01 00:00					
+%R	7375	10596	1	0.00	2013-01-01 00:00					
+%R	7376	10597	1	0.00	2013-01-01 00:00					
+%R	7377	10598	1	0.00	2013-01-01 00:00					
+%R	7378	10599	1	0.00	2013-01-01 00:00					
+%R	7379	10600	1	0.00	2013-01-01 00:00					
+%R	7381	10602	1	0.00	2013-01-01 00:00					
+%R	7382	10603	1	0.00	2013-01-01 00:00					
+%R	7383	10604	1	0.00	2013-01-01 00:00					
+%R	7384	10605	1	0.00	2013-01-01 00:00					
+%R	7385	10606	1	0.00	2013-01-01 00:00					
+%R	7386	10607	1	0.00	2013-01-01 00:00					
+%R	7387	10608	1	0.00	2013-01-01 00:00					
+%R	7388	10609	1	0.00	2013-01-01 00:00					
+%R	7389	10610	1	0.00	2013-01-01 00:00					
+%R	7390	10611	1	0.00	2013-01-01 00:00					
+%R	7391	10612	1	0.00	2013-01-01 00:00					
+%R	7393	10614	1	0.00	2013-01-01 00:00					
+%T	RSRCRCAT
+%F	rsrc_id	rsrc_catg_type_id	rsrc_catg_id
+%R	10552	112	778
+%R	10553	112	778
+%R	10554	112	778
+%R	10555	112	779
+%R	10557	113	782
+%R	10558	113	782
+%R	10559	114	784
+%R	10560	114	784
+%R	10562	114	784
+%R	10563	114	784
+%T	TASK
+%F	task_id	proj_id	wbs_id	clndr_id	phys_complete_pct	rev_fdbk_flag	lock_plan_flag	auto_compute_act_flag	complete_pct_type	task_type	duration_type	status_code	task_code	task_name	rsrc_id	total_float_hr_cnt	free_float_hr_cnt	remain_drtn_hr_cnt	act_work_qty	remain_work_qty	target_work_qty	target_drtn_hr_cnt	target_equip_qty	act_equip_qty	remain_equip_qty	cstr_date	act_start_date	act_end_date	late_start_date	late_end_date	expect_end_date	early_start_date	early_end_date	restart_date	reend_date	target_start_date	target_end_date	rem_late_start_date	rem_late_end_date	cstr_type	priority_type	suspend_date	resume_date	float_path	float_path_order	guid	tmpl_guid	cstr_date2	cstr_type2	driving_path_flag	act_this_per_work_qty	act_this_per_equip_qty	external_early_start_date	external_late_end_date	create_date	update_date	create_user	update_user	location_id
+%R	106071	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	10	EXCAVATION		0	0	100	0	0	0	100	304	0	304				2013-09-16 12:00	2013-09-30 16:00		2013-09-16 12:00	2013-09-30 16:00	2013-09-16 12:00	2013-09-30 16:00	2013-09-16 12:00	2013-09-30 16:00	2013-09-16 12:00	2013-09-30 16:00		PT_Normal					NdRv+yWCW0G656oEZI330w				Y	0	0			2013-08-03 16:43	2013-09-14 22:01	admin	admin	
+%R	106222	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	20	REPLACMENT LAYER	10566	0	0	70	0	1500	1500	70	0	0	0				2013-10-01 08:00	2013-10-10 14:00		2013-10-01 08:00	2013-10-10 14:00	2013-10-01 08:00	2013-10-10 14:00	2013-10-01 08:00	2013-10-10 14:00	2013-10-01 08:00	2013-10-10 14:00		PT_Normal					OER4hqtcIUO58BPf9FXkag				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106223	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	30	BACKFILL		0	0	50	0	0	0	50	96	0	96				2013-11-26 14:00	2013-12-04 16:00		2013-11-26 14:00	2013-12-04 16:00	2013-11-26 14:00	2013-12-04 16:00	2013-11-26 14:00	2013-12-04 16:00	2013-11-26 14:00	2013-12-04 16:00		PT_Normal					J6FITstXFUm0WN55H0M1UQ				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106224	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	40	P.C	10557	0	0	70	0	255	255	70	0	0	0				2013-10-10 14:00	2013-10-21 12:00		2013-10-10 14:00	2013-10-21 12:00	2013-10-10 14:00	2013-10-21 12:00	2013-10-10 14:00	2013-10-21 12:00	2013-10-10 14:00	2013-10-21 12:00		PT_Normal					gmVE/blAnkGDJuBObsGs2w				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106225	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	50	R.C	10557	0	0	120	0	933	933	120	0	0	0				2013-10-21 12:00	2013-11-07 12:00		2013-10-21 12:00	2013-11-07 12:00	2013-10-21 12:00	2013-11-07 12:00	2013-10-21 12:00	2013-11-07 12:00	2013-10-21 12:00	2013-11-07 12:00		PT_Normal					g1TK0lw77EmN666hANXhkg				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106226	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	60	NECK COLUMN	10557	0	0	70	0	9933	9933	70	0	0	0				2013-11-07 12:00	2013-11-18 10:00		2013-11-07 12:00	2013-11-18 10:00	2013-11-07 12:00	2013-11-18 10:00	2013-11-07 12:00	2013-11-18 10:00	2013-11-07 12:00	2013-11-18 10:00		PT_Normal					FQX9aRdj0U29Lo04eIANZQ				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106227	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	70	SLAB ON GRADE	10558	0	0	20	0	22	22	20	0	0	0				2013-12-05 08:00	2013-12-08 12:00		2013-12-05 08:00	2013-12-08 12:00	2013-12-05 08:00	2013-12-08 12:00	2013-12-05 08:00	2013-12-08 12:00	2013-12-05 08:00	2013-12-08 12:00		PT_Normal					jPbqAMF5K0KAn/6PMibYOQ				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106228	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	80	DAMP PROOFING	10606	0	0	20	0	4	4	20	0	0	0				2013-11-23 08:00	2013-11-25 12:00		2013-11-23 08:00	2013-11-25 12:00	2013-11-23 08:00	2013-11-25 12:00	2013-11-23 08:00	2013-11-25 12:00	2013-11-23 08:00	2013-11-25 12:00		PT_Normal					8wsv9cg29k+3feRpYPew3Q				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106229	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	90	INSULATION	10562	0	0	10	0	255	255	10	0	0	0				2013-11-25 12:00	2013-11-26 14:00		2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00		PT_Normal					uMt4qmbLYEe5NPpe555Z4A				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106230	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	100	BRICK WORK	10564	0	0	30	0	22	22	30	0	0	0				2013-11-18 10:00	2013-11-21 16:00		2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00		PT_Normal					2qsxBkKo4k2BmgZAgPUmYg				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106231	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	110	BASEMENT COLUMN	10558	0	0	70	0	79	79	70	0	0	0				2013-12-08 12:00	2013-12-18 10:00		2013-12-08 12:00	2013-12-18 10:00	2013-12-08 12:00	2013-12-18 10:00	2013-12-08 12:00	2013-12-18 10:00	2013-12-08 12:00	2013-12-18 10:00		PT_Normal					Z5kFqDv7j0WVo84W6MJNhA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106232	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	120	BASEMENT SLAB	10557	0	0	100	0	399	399	100	0	0	0				2013-12-18 10:00	2014-01-02 14:00		2013-12-18 10:00	2014-01-02 14:00	2013-12-18 10:00	2014-01-02 14:00	2013-12-18 10:00	2014-01-02 14:00	2013-12-18 10:00	2014-01-02 14:00		PT_Normal					PaQvmWcHC0ugWRPQSkgu8A				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106233	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	130	GROUND COLUMN	10557	0	0	70	0	135	135	70	0	0	0				2014-01-02 14:00	2014-01-13 12:00		2014-01-02 14:00	2014-01-13 12:00	2014-01-02 14:00	2014-01-13 12:00	2014-01-02 14:00	2014-01-13 12:00	2014-01-02 14:00	2014-01-13 12:00		PT_Normal					Yw8auPr0xUGbCOO3Qk2JWA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106234	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	140	GROUND SLAB	10557	0	0	110	0	369	369	110	0	0	0				2014-01-13 12:00	2014-01-29 10:00		2014-01-13 12:00	2014-01-29 10:00	2014-01-13 12:00	2014-01-29 10:00	2014-01-13 12:00	2014-01-29 10:00	2014-01-13 12:00	2014-01-29 10:00		PT_Normal					Tque+JIuMUaGWl5m0JIIbw				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106235	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	150	1ST FLOOR COLUMN	10557	90	0	70	0	104	104	70	0	0	0				2014-02-11 12:00	2014-02-22 10:00		2014-01-29 10:00	2014-02-08 16:00	2014-01-29 10:00	2014-02-08 16:00	2014-01-29 10:00	2014-02-08 16:00	2014-02-11 12:00	2014-02-22 10:00		PT_Normal					KaVz2yCP3Ue6CyFQDoVhNw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106236	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	160	1ST FLOOR SLAB	10558	90	0	100	0	385	385	100	0	0	0				2014-02-22 10:00	2014-03-08 14:00		2014-02-09 08:00	2014-02-23 12:00	2014-02-09 08:00	2014-02-23 12:00	2014-02-09 08:00	2014-02-23 12:00	2014-02-22 10:00	2014-03-08 14:00		PT_Normal					s6/2erBkAkOOCGRRmHvOww				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106237	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	170	2ND FLOOR COLUMN	10557	180	0	70	0	70	70	70	0	0	0				2014-03-22 08:00	2014-03-31 14:00		2014-02-23 12:00	2014-03-05 10:00	2014-02-23 12:00	2014-03-05 10:00	2014-02-23 12:00	2014-03-05 10:00	2014-03-22 08:00	2014-03-31 14:00		PT_Normal					hS9QXAYCoUGIZEsj/GH3wA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106238	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	180	2ND FLOOR SLAB	10557	180	0	100	0	489	489	100	0	0	0				2014-03-31 14:00	2014-04-15 10:00		2014-03-05 10:00	2014-03-19 14:00	2014-03-05 10:00	2014-03-19 14:00	2014-03-05 10:00	2014-03-19 14:00	2014-03-31 14:00	2014-04-15 10:00		PT_Normal					7hW8ihpySk2pM/O83rvmVg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106239	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	190	3RD FLOOR COLUMN	10557	270	0	70	0	62	62	70	0	0	0				2014-04-28 12:00	2014-05-08 10:00		2014-03-19 14:00	2014-03-30 12:00	2014-03-19 14:00	2014-03-30 12:00	2014-03-19 14:00	2014-03-30 12:00	2014-04-28 12:00	2014-05-08 10:00		PT_Normal					oOL4s+hbiEG9Qy7wvm3Xsw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106240	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	200	3RD FLOOR SLAB	10557	270	0	100	0	327	327	100	0	0	0				2014-05-08 10:00	2014-05-22 14:00		2014-03-30 12:00	2014-04-13 16:00	2014-03-30 12:00	2014-04-13 16:00	2014-03-30 12:00	2014-04-13 16:00	2014-05-08 10:00	2014-05-22 14:00		PT_Normal					epriZ8TaREWIqEjEA7zqpw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106241	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	210	ROOF FLOOR COLUMN	10558	460	0	50	0	39	39	50	0	0	0				2014-06-19 12:00	2014-06-26 14:00		2014-04-14 08:00	2014-04-21 10:00	2014-04-14 08:00	2014-04-21 10:00	2014-04-14 08:00	2014-04-21 10:00	2014-06-19 12:00	2014-06-26 14:00		PT_Normal					bZ3/H3z7xUaRg9YUTQUm6w				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106242	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	220	ROOF FLOOR SLAB	10558	460	0	50	0	39	39	50	0	0	0				2014-06-26 14:00	2014-07-03 16:00		2014-04-21 10:00	2014-04-28 12:00	2014-04-21 10:00	2014-04-28 12:00	2014-04-21 10:00	2014-04-28 12:00	2014-06-26 14:00	2014-07-03 16:00		PT_Normal					+e14J44HzUeSKz1T+79d8Q				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106243	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	230	B. FLOOR MASONARY WORK	10564	0	0	30	0	1306	1306	30	0	0	0				2014-01-29 10:00	2014-02-02 16:00		2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00		PT_Normal					sVw2iSRPyk6j3zwqcGLgkQ				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106244	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	240	WINDOWS&DOORS		330	0	140	0	0	0	140	0	0	0				2014-03-23 10:00	2014-04-12 14:00		2014-02-03 08:00	2014-02-23 12:00	2014-02-03 08:00	2014-02-23 12:00	2014-02-03 08:00	2014-02-23 12:00	2014-03-23 10:00	2014-04-12 14:00		PT_Normal					twKxEhbX00mj0SgZwLtsCA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106245	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	250	PLASTER	10572	0	0	140	0	1103	1103	140	0	0	0				2014-02-12 14:00	2014-03-05 10:00		2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00		PT_Normal					NR+4POwq40qmrtuYFYG+ZA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106246	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	260	CERMIC	10573	2040	0	50	0	161	161	50	0	0	0				2014-12-07 14:00	2014-12-14 16:00		2014-02-12 14:00	2014-02-19 16:00	2014-02-12 14:00	2014-02-19 16:00	2014-02-12 14:00	2014-02-19 16:00	2014-12-07 14:00	2014-12-14 16:00		PT_Normal					F88MvVGZWk+TupRS1fwndw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106247	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	270	INTIAL PAINTING	10577	450	0	120	0	675	675	120	0	0	0				2014-06-21 14:00	2014-07-08 14:00		2014-04-16 12:00	2014-05-04 12:00	2014-04-16 12:00	2014-05-04 12:00	2014-04-16 12:00	2014-05-04 12:00	2014-06-21 14:00	2014-07-08 14:00		PT_Normal					ee66gq9CrEygMVUrl3eTQg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106248	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	280	GR. FLOOR MASONARY WORK	10564	50	0	90	0	1087	1087	90	0	0	0				2014-02-10 10:00	2014-02-23 12:00		2014-02-03 08:00	2014-02-16 10:00	2014-02-03 08:00	2014-02-16 10:00	2014-02-03 08:00	2014-02-16 10:00	2014-02-10 10:00	2014-02-23 12:00		PT_Normal					Ciu/5J52UEahWMoo9pkB9w				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106249	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	290	WINDOWS&DOORS		330	0	140	0	0	0	140	0	0	0				2014-04-12 14:00	2014-05-03 10:00		2014-02-23 12:00	2014-03-15 16:00	2014-02-23 12:00	2014-03-15 16:00	2014-02-23 12:00	2014-03-15 16:00	2014-04-12 14:00	2014-05-03 10:00		PT_Normal					XP2xOswtI0C0Fog0wBVZZg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106250	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	300	PLASTER	10572	0	0	200	0	2098	2098	200	0	0	0				2014-03-05 10:00	2014-04-03 10:00		2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00		PT_Normal					6LmQ7qVUykGaMQ4BPIZXlA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106251	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	310	MATEL LATH	10579	450	0	40	0	34	34	40	0	0	0				2014-06-15 14:00	2014-06-21 14:00		2014-04-10 12:00	2014-04-16 12:00	2014-04-10 12:00	2014-04-16 12:00	2014-04-10 12:00	2014-04-16 12:00	2014-06-15 14:00	2014-06-21 14:00		PT_Normal					N3unZqfDtEOMaLX5dYVIFA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106252	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	320	CERMIC	10574	2040	0	100	0	321	321	100	0	0	0				2014-12-15 08:00	2014-12-29 12:00		2014-02-20 08:00	2014-03-06 12:00	2014-02-20 08:00	2014-03-06 12:00	2014-02-20 08:00	2014-03-06 12:00	2014-12-15 08:00	2014-12-29 12:00		PT_Normal					/RHu+NJolESlQrWTWdXWXg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106253	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	330	INTIAL PAINTING	10577	330	0	200	0	1119	1119	200	0	0	0				2014-07-10 08:00	2014-08-07 16:00		2014-05-22 14:00	2014-06-21 14:00	2014-05-22 14:00	2014-06-21 14:00	2014-05-22 14:00	2014-06-21 14:00	2014-07-10 08:00	2014-08-07 16:00		PT_Normal					fSDjXQyg8UqhuOJJy1BA1g				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106254	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_Active	340	1ST FLOOR MASONARY WORK	10564	90	0	110	8000	67	1079	110	0	0	0		2014-02-23 12:00		2014-03-08 14:00	2014-03-24 12:00		2014-02-23 12:00	2014-03-11 10:00	2014-02-23 12:00	2014-03-11 10:00	2014-02-23 12:00	2014-03-11 10:00	2014-03-08 14:00	2014-03-24 12:00		PT_Normal					XVlasn7EnUiKAAoI/YckkQ				N	8000	0			2013-08-03 16:51	2013-09-17 20:01	admin	NotPrmUser	
+%R	106255	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	350	WINDOWS&DOORS		330	0	140	0	0	0	140	0	0	0				2014-05-03 10:00	2014-05-22 14:00		2014-03-16 08:00	2014-04-05 12:00	2014-03-16 08:00	2014-04-05 12:00	2014-03-16 08:00	2014-04-05 12:00	2014-05-03 10:00	2014-05-22 14:00		PT_Normal					+vOIz/ZwOkG+LEtKllLQcw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106256	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	360	PLASTER	10572	0	0	250	0	2960	2960	250	0	0	0				2014-04-03 10:00	2014-05-10 12:00		2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00		PT_Normal					cUtBF7m2vUSM4LMoJswjTg				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106257	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	370	MATEL LATH	10579	330	0	40	0	42	42	40	0	0	0				2014-07-05 08:00	2014-07-09 16:00		2014-05-17 14:00	2014-05-22 14:00	2014-05-17 14:00	2014-05-22 14:00	2014-05-17 14:00	2014-05-22 14:00	2014-07-05 08:00	2014-07-09 16:00		PT_Normal					89V/A/tpMkaqE8Ztpa5DOQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106258	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	380	CERMIC	10574	1940	0	100	0	338	338	100	0	0	0				2014-12-29 12:00	2015-01-12 16:00		2014-03-22 08:00	2014-04-05 12:00	2014-03-22 08:00	2014-04-05 12:00	2014-03-22 08:00	2014-04-05 12:00	2014-12-29 12:00	2015-01-12 16:00		PT_Normal					xrYIlZcdPUOQENvsis3Rng				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106259	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	390	INTIAL PAINTING	10577	290	0	150	0	1620	1620	150	0	0	0				2014-08-11 12:00	2014-09-02 10:00		2014-06-30 10:00	2014-07-21 16:00	2014-06-30 10:00	2014-07-21 16:00	2014-06-30 10:00	2014-07-21 16:00	2014-08-11 12:00	2014-09-02 10:00		PT_Normal					7qqUzYYW1UmD81sLWz4CpA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106260	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	400	2ND FLOOR MASONARY WORK	10564	180	0	100	0	1214	1214	100	0	0	0				2014-04-15 10:00	2014-04-29 14:00		2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00		PT_Normal					sOkV7YO+kkCEpQKfSZOJqg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106261	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	410	WINDOWS&DOORS		330	0	140	0	0	0	140	0	0	0				2014-05-22 14:00	2014-06-12 10:00		2014-04-05 12:00	2014-04-24 16:00	2014-04-05 12:00	2014-04-24 16:00	2014-04-05 12:00	2014-04-24 16:00	2014-05-22 14:00	2014-06-12 10:00		PT_Normal					IVEq8G23RUWSJmpTI6qFkw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106262	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	420	PLASTER	10572	0	0	260	0	3076	3076	260	0	0	0				2014-05-10 12:00	2014-06-16 16:00		2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00		PT_Normal					oUlpxRLcoU2qTHyYn6vJTA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106263	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	430	MATEL LATH	10579	290	0	40	0	46	46	40	0	0	0				2014-08-05 12:00	2014-08-11 12:00		2014-06-24 10:00	2014-06-30 10:00	2014-06-24 10:00	2014-06-30 10:00	2014-06-24 10:00	2014-06-30 10:00	2014-08-05 12:00	2014-08-11 12:00		PT_Normal					nWRNXyheHUmKOznPtHSYRw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106264	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	440	CERMIC	10574	1880	0	100	0	470	470	100	0	0	0				2015-01-13 08:00	2015-01-27 12:00		2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2015-01-13 08:00	2015-01-27 12:00		PT_Normal					Lfg6IK1rAESus8Ad+zaWoQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106265	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	450	INTIAL PAINTING	10577	210	0	160	0	18601	18601	160	0	0	0				2014-09-02 10:00	2014-09-25 10:00		2014-08-03 08:00	2014-08-25 16:00	2014-08-03 08:00	2014-08-25 16:00	2014-08-03 08:00	2014-08-25 16:00	2014-09-02 10:00	2014-09-25 10:00		PT_Normal					0CxSLSCEGEGFYHV8Ro3zHg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106266	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	460	3RD FLOOR MASONARY WORK	10564	270	0	100	0	1377	1377	100	0	0	0				2014-05-22 14:00	2014-06-07 10:00		2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2014-05-22 14:00	2014-06-07 10:00		PT_Normal					sGq4N4olhU+jKQaHP9aZwA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106267	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	470	WINDOWS&DOORS		310	0	140	0	0	0	140	0	0	0				2014-06-12 10:00	2014-07-02 14:00		2014-04-28 12:00	2014-05-18 16:00	2014-04-28 12:00	2014-05-18 16:00	2014-04-28 12:00	2014-05-18 16:00	2014-06-12 10:00	2014-07-02 14:00		PT_Normal					RFzEJYtz+kGaBMbRDXMq9Q				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106268	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	480	PLASTER	10572	0	0	230	0	2646	2646	230	0	0	0				2014-06-17 08:00	2014-07-20 14:00		2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00		PT_Normal					QCu6QnEJ4EeP/g8F/U8Gvw				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106269	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	490	MATEL LATH	10579	210	0	40	0	39	39	40	0	0	0				2014-08-27 10:00	2014-09-02 10:00		2014-07-28 08:00	2014-08-02 16:00	2014-07-28 08:00	2014-08-02 16:00	2014-07-28 08:00	2014-08-02 16:00	2014-08-27 10:00	2014-09-02 10:00		PT_Normal					yv4KPt+LpkC8ashFhuNLbQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106270	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	500	CERMIC	10574	1810	0	110	0	428	428	110	0	0	0				2015-01-27 12:00	2015-02-12 10:00		2014-05-08 10:00	2014-05-24 16:00	2014-05-08 10:00	2014-05-24 16:00	2014-05-08 10:00	2014-05-24 16:00	2015-01-27 12:00	2015-02-12 10:00		PT_Normal					JGRiJdzwZUWily6G+7J4Vg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106271	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	510	INTIAL PAINTING	10577	210	0	90	0	254	254	90	0	0	0				2014-09-25 10:00	2014-10-08 12:00		2014-08-26 08:00	2014-09-08 10:00	2014-08-26 08:00	2014-09-08 10:00	2014-08-26 08:00	2014-09-08 10:00	2014-09-25 10:00	2014-10-08 12:00		PT_Normal					AQtNUCFyG0i9mqPISVucmg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106272	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	520	ROOF FLOOR MASONARY WORK	10564	460	50	20	0	187	187	20	0	0	0				2014-07-05 08:00	2014-07-07 12:00		2014-04-28 12:00	2014-04-30 16:00	2014-04-28 12:00	2014-04-30 16:00	2014-04-28 12:00	2014-04-30 16:00	2014-07-05 08:00	2014-07-07 12:00		PT_Normal					1Apqx9E1zUO7cI1isMRHyg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106273	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	530	WINDOWS&DOORS		340	30	70	0	0	0	70	0	0	0				2014-07-07 12:00	2014-07-17 10:00		2014-05-19 08:00	2014-05-28 14:00	2014-05-19 08:00	2014-05-28 14:00	2014-05-19 08:00	2014-05-28 14:00	2014-07-07 12:00	2014-07-17 10:00		PT_Normal					vfvMjmwRPUO0A7lXvdu8XA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106274	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	540	PLASTER	10572	0	0	80	0	880	880	80	0	0	0				2014-07-20 14:00	2014-07-31 14:00		2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00		PT_Normal					SxcqkchfwUOU36UwCXdWTw				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106275	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	550	MATEL LATH	10579	290	80	40	0	25	25	40	0	0	0				2014-09-20 10:00	2014-09-25 10:00		2014-08-09 08:00	2014-08-13 16:00	2014-08-09 08:00	2014-08-13 16:00	2014-08-09 08:00	2014-08-13 16:00	2014-09-20 10:00	2014-09-25 10:00		PT_Normal					+NQrSfuCDEibEqeZihh6Ig				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106276	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	560	 PROOFING	10583	1050	0	40	0	567	567	40	0	0	0				2015-01-01 08:00	2015-01-06 16:00		2014-07-31 14:00	2014-08-06 14:00	2014-07-31 14:00	2014-08-06 14:00	2014-07-31 14:00	2014-08-06 14:00	2015-01-01 08:00	2015-01-06 16:00		PT_Normal					TWTU34LaN0u/Lr1/bO4XxQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106277	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	570	THERMAL INSULATION	10606	1050	0	40	0	15	15	40	0	0	0				2015-01-07 08:00	2015-01-12 16:00		2014-08-06 14:00	2014-08-12 14:00	2014-08-06 14:00	2014-08-12 14:00	2014-08-06 14:00	2014-08-12 14:00	2015-01-07 08:00	2015-01-12 16:00		PT_Normal					hmn8c0cuOUKqs7I+3p2inw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106278	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	580	P. C. SCREED	10603	1050	0	10	0	2	2	10	0	0	0				2015-01-13 08:00	2015-01-14 10:00		2014-08-12 14:00	2014-08-13 16:00	2014-08-12 14:00	2014-08-13 16:00	2014-08-12 14:00	2014-08-13 16:00	2015-01-13 08:00	2015-01-14 10:00		PT_Normal					g9rLNbk0kUeOQ8KPhqxPQw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106279	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	590	PLASTER	10572	0	0	170	0	1516	1516	170	0	0	0				2014-07-31 14:00	2014-08-25 16:00		2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00		PT_Normal					iKSddU2ZDU2JS4hmQBGfLA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106280	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	600	CERETAL WORK		1030	410	140	0	0	0	140	0	0	0				2015-01-22 14:00	2015-02-12 10:00		2014-08-26 08:00	2014-09-15 12:00	2014-08-26 08:00	2014-09-15 12:00	2014-08-26 08:00	2014-09-15 12:00	2015-01-22 14:00	2015-02-12 10:00		PT_Normal					sSIhh6oH2UWuq1luqxmDkg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106281	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	610	PLASTER	10572	0	0	550	0	5667	5667	550	0	0	0				2014-08-26 08:00	2014-11-13 14:00		2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00		PT_Normal					Iy+5RKM6P0G4JmedYGy1YA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106282	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	620	RED TILES	10582	620	0	50	0	78	78	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					Un/4ZBwCL0iDqI8U/yNOeg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106283	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	630	WINDOWS&DOORS		1000	0	140	0	0	0	140	0	0	0				2014-09-27 12:00	2014-10-16 16:00		2014-05-04 12:00	2014-05-24 16:00	2014-05-04 12:00	2014-05-24 16:00	2014-05-04 12:00	2014-05-24 16:00	2014-09-27 12:00	2014-10-16 16:00		PT_Normal					zbRETJoPtEqOT8ljE9DqkQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106284	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	640	PAINTING	10577	1000	0	100	0	675	675	100	0	0	0				2014-10-18 08:00	2014-11-01 12:00		2014-05-25 08:00	2014-06-08 12:00	2014-05-25 08:00	2014-06-08 12:00	2014-05-25 08:00	2014-06-08 12:00	2014-10-18 08:00	2014-11-01 12:00		PT_Normal					pCT2QcjirEyO8Y1YTY/xmA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106285	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	650	WOODEN FLOORS		450	0	70	0	0	0	70	0	0	0				2014-08-09 08:00	2014-08-18 14:00		2014-06-03 14:00	2014-06-14 12:00	2014-06-03 14:00	2014-06-14 12:00	2014-06-03 14:00	2014-06-14 12:00	2014-08-09 08:00	2014-08-18 14:00		PT_Normal					JnQVJeI+30ODDLKIDT2GsQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106286	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	660	MARBLE FLOORS	10582	450	0	100	0	304	304	100	0	0	0				2014-08-09 08:00	2014-08-23 12:00		2014-06-03 14:00	2014-06-18 10:00	2014-06-03 14:00	2014-06-18 10:00	2014-06-03 14:00	2014-06-18 10:00	2014-08-09 08:00	2014-08-23 12:00		PT_Normal					1EV6KHvPPUW0GH5D6MjpWQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106287	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	670	FINISHING FLOORS	10588	450	0	70	0	338	338	70	0	0	0				2014-08-09 08:00	2014-08-18 14:00		2014-06-03 14:00	2014-06-14 12:00	2014-06-03 14:00	2014-06-14 12:00	2014-06-03 14:00	2014-06-14 12:00	2014-08-09 08:00	2014-08-18 14:00		PT_Normal					1sg/oqloLE+SIePrhLb0vg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106288	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	680	ALUMINUM		450	0	210	0	0	0	210	0	0	0				2014-07-08 14:00	2014-08-07 16:00		2014-05-04 12:00	2014-06-03 14:00	2014-05-04 12:00	2014-06-03 14:00	2014-05-04 12:00	2014-06-03 14:00	2014-07-08 14:00	2014-08-07 16:00		PT_Normal					3J/PBDLLikyDseca/TXGVA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106289	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	690	DOOR		450	0	210	0	0	0	210	0	0	0				2014-08-18 14:00	2014-09-17 16:00		2014-06-14 12:00	2014-07-14 14:00	2014-06-14 12:00	2014-07-14 14:00	2014-06-14 12:00	2014-07-14 14:00	2014-08-18 14:00	2014-09-17 16:00		PT_Normal					yI1TyrIgXUa3+B/rWG80ow				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106290	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	700	PAINTING	10577	750	0	110	0	1117	1117	110	0	0	0				2014-11-01 12:00	2014-11-17 10:00		2014-07-14 14:00	2014-07-30 12:00	2014-07-14 14:00	2014-07-30 12:00	2014-07-14 14:00	2014-07-30 12:00	2014-11-01 12:00	2014-11-17 10:00		PT_Normal					HADFrrCaWES3COPufMlU9A				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106291	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	710	WOODEN FLOORS		330	0	140	0	0	0	140	0	0	0				2014-09-08 10:00	2014-09-28 14:00		2014-07-22 08:00	2014-08-11 12:00	2014-07-22 08:00	2014-08-11 12:00	2014-07-22 08:00	2014-08-11 12:00	2014-09-08 10:00	2014-09-28 14:00		PT_Normal					Ued+jB1HE0u5LXKbiIZXBg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106292	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	720	MARBLE FLOORS	10582	330	0	70	0	254	254	70	0	0	0				2014-09-08 10:00	2014-09-17 16:00		2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-09-08 10:00	2014-09-17 16:00		PT_Normal					SSEy2xGWwUin/8Mk1sDgWA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106293	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	730	FINISHING FLOORS	10588	330	0	70	0	444	444	70	0	0	0				2014-09-08 10:00	2014-09-17 16:00		2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-09-08 10:00	2014-09-17 16:00		PT_Normal					pEyFUiahJ0uMhoOImsRRag				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106294	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	740	ALUMINUM		330	0	210	0	0	0	210	0	0	0				2014-08-09 08:00	2014-09-08 10:00		2014-06-21 14:00	2014-07-21 16:00	2014-06-21 14:00	2014-07-21 16:00	2014-06-21 14:00	2014-07-21 16:00	2014-08-09 08:00	2014-09-08 10:00		PT_Normal					kqoENRd5RkiqnkDy5dYrSQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106295	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	750	DOOR		330	0	210	0	0	0	210	0	0	0				2014-09-18 08:00	2014-10-19 10:00		2014-07-31 14:00	2014-08-31 16:00	2014-07-31 14:00	2014-08-31 16:00	2014-07-31 14:00	2014-08-31 16:00	2014-09-18 08:00	2014-10-19 10:00		PT_Normal					SAh1/D89cUGu/VSHn41yzQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106296	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	760	PAINTING	10577	530	0	100	0	1613	1613	100	0	0	0				2014-11-17 10:00	2014-12-01 14:00		2014-09-01 08:00	2014-09-15 12:00	2014-09-01 08:00	2014-09-15 12:00	2014-09-01 08:00	2014-09-15 12:00	2014-11-17 10:00	2014-12-01 14:00		PT_Normal					eZmgkia3xESpHqxrCuXPDg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106297	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	770	WOODEN FLOORS		330	0	140	0	0	0	140	0	0	0				2014-10-08 12:00	2014-10-28 16:00		2014-08-21 10:00	2014-09-10 14:00	2014-08-21 10:00	2014-09-10 14:00	2014-08-21 10:00	2014-09-10 14:00	2014-10-08 12:00	2014-10-28 16:00		PT_Normal					m1fFgnpH6kOs3haUIFTABg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106298	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	780	MARBLE FLOORS	10582	330	0	50	0	263	263	50	0	0	0				2014-10-08 12:00	2014-10-15 14:00		2014-08-21 10:00	2014-08-28 12:00	2014-08-21 10:00	2014-08-28 12:00	2014-08-21 10:00	2014-08-28 12:00	2014-10-08 12:00	2014-10-15 14:00		PT_Normal					A7n6oJpLDUGpVVj5N8puUg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106299	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	790	FINISHING FLOORS	10588	330	0	70	0	430	430	70	0	0	0				2014-10-08 12:00	2014-10-19 10:00		2014-08-21 10:00	2014-08-31 16:00	2014-08-21 10:00	2014-08-31 16:00	2014-08-21 10:00	2014-08-31 16:00	2014-10-08 12:00	2014-10-19 10:00		PT_Normal					QtA/JuvJ60aFH88eY5p9UA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106300	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	800	ALUMINUM		330	0	210	0	0	0	210	0	0	0				2014-09-08 10:00	2014-10-08 12:00		2014-07-22 08:00	2014-08-21 10:00	2014-07-22 08:00	2014-08-21 10:00	2014-07-22 08:00	2014-08-21 10:00	2014-09-08 10:00	2014-10-08 12:00		PT_Normal					rTC7UGb0PkiZGLjpEeKgng				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106301	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	810	DOOR		330	0	210	0	0	0	210	0	0	0				2014-10-19 10:00	2014-11-18 12:00		2014-09-01 08:00	2014-10-01 10:00	2014-09-01 08:00	2014-10-01 10:00	2014-09-01 08:00	2014-10-01 10:00	2014-10-19 10:00	2014-11-18 12:00		PT_Normal					DBVOhlRAyE2MNp1mpppeQw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106302	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	820	PAINTING	10577	420	0	110	0	248	248	110	0	0	0				2014-12-01 14:00	2014-12-17 12:00		2014-10-01 10:00	2014-10-16 16:00	2014-10-01 10:00	2014-10-16 16:00	2014-10-01 10:00	2014-10-16 16:00	2014-12-01 14:00	2014-12-17 12:00		PT_Normal					spai7TloXk6rd0tY43i06Q				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106303	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	830	WOODEN FLOORS		210	0	140	0	0	0	140	0	0	0				2014-11-08 14:00	2014-11-29 10:00		2014-10-08 12:00	2014-10-28 16:00	2014-10-08 12:00	2014-10-28 16:00	2014-10-08 12:00	2014-10-28 16:00	2014-11-08 14:00	2014-11-29 10:00		PT_Normal					vw7KJXRc4Ua9sB6qoqQPNw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106304	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	840	MARBLE FLOORS	10582	210	0	50	0	267	267	50	0	0	0				2014-11-08 14:00	2014-11-15 16:00		2014-10-08 12:00	2014-10-15 14:00	2014-10-08 12:00	2014-10-15 14:00	2014-10-08 12:00	2014-10-15 14:00	2014-11-08 14:00	2014-11-15 16:00		PT_Normal					4hC8BQTatEWggJ4DSk/npw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106305	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	850	FINISHING FLOORS	10588	210	0	70	0	394	394	70	0	0	0				2014-11-08 14:00	2014-11-18 12:00		2014-10-08 12:00	2014-10-19 10:00	2014-10-08 12:00	2014-10-19 10:00	2014-10-08 12:00	2014-10-19 10:00	2014-11-08 14:00	2014-11-18 12:00		PT_Normal					4KD+vaFLVU23xUfWkJ6fpw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106306	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	860	ALUMINUM		210	0	210	0	0	0	210	0	0	0				2014-10-08 12:00	2014-11-08 14:00		2014-09-08 10:00	2014-10-08 12:00	2014-09-08 10:00	2014-10-08 12:00	2014-09-08 10:00	2014-10-08 12:00	2014-10-08 12:00	2014-11-08 14:00		PT_Normal					K4BPDkiG0EiQm4mG0qfnBw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106307	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	870	DOOR		210	0	210	0	0	0	210	0	0	0				2014-11-18 12:00	2014-12-18 14:00		2014-10-19 10:00	2014-11-18 12:00	2014-10-19 10:00	2014-11-18 12:00	2014-10-19 10:00	2014-11-18 12:00	2014-11-18 12:00	2014-12-18 14:00		PT_Normal					gHT42EjnMU+fpT8PWK+XSQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106308	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	880	PAINTING	10577	210	0	90	0	1474	1474	90	0	0	0				2014-12-18 14:00	2014-12-31 16:00		2014-11-18 12:00	2014-12-01 14:00	2014-11-18 12:00	2014-12-01 14:00	2014-11-18 12:00	2014-12-01 14:00	2014-12-18 14:00	2014-12-31 16:00		PT_Normal					lP1ql3uZr0eXS4WwpP1yig				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106309	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	890	CEMENT TILES	10582	1050	0	90	0	766	766	90	0	0	0				2015-01-14 10:00	2015-01-27 12:00		2014-08-14 08:00	2014-08-27 10:00	2014-08-14 08:00	2014-08-27 10:00	2014-08-14 08:00	2014-08-27 10:00	2015-01-14 10:00	2015-01-27 12:00		PT_Normal					sDUNjBqgDUGW61CpmOg0UA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106310	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	900	FACADES PLASTER	10572	1050	480	90	0	473	473	90	0	0	0				2015-01-27 12:00	2015-02-09 14:00		2014-08-27 10:00	2014-09-09 12:00	2014-08-27 10:00	2014-09-09 12:00	2014-08-27 10:00	2014-09-09 12:00	2015-01-27 12:00	2015-02-09 14:00		PT_Normal					2EZQB/WVcEmYyNMvWcAOAw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106311	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	910	DOOR		570	400	70	0	0	0	70	0	0	0				2015-02-09 14:00	2015-02-19 12:00		2014-11-18 12:00	2014-11-29 10:00	2014-11-18 12:00	2014-11-29 10:00	2014-11-18 12:00	2014-11-29 10:00	2015-02-09 14:00	2015-02-19 12:00		PT_Normal					UW19H/Ny/Emy4yTR7V7nDQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106312	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	920	CERETAL WORK		0	0	210	0	0	0	210	0	0	0				2014-07-26 14:00	2014-08-25 16:00		2014-07-26 14:00	2014-08-25 16:00	2014-07-26 14:00	2014-08-25 16:00	2014-07-26 14:00	2014-08-25 16:00	2014-07-26 14:00	2014-08-25 16:00		PT_Normal					FzIeezRlhEWmVLGhOH8Ljg				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106313	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	930	PLASTER COLORD	10572	710	0	130	0	760	760	130	0	0	0				2014-12-15 08:00	2015-01-03 10:00		2014-09-02 10:00	2014-09-21 12:00	2014-09-02 10:00	2014-09-21 12:00	2014-09-02 10:00	2014-09-21 12:00	2014-12-15 08:00	2015-01-03 10:00		PT_Normal					N1o41Z5AxESOlm2fAfVw2Q				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106314	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	940	MARBLE FLOORS	10582	710	0	80	0	195	195	80	0	0	0				2015-01-03 10:00	2015-01-14 10:00		2014-09-21 12:00	2014-10-02 12:00	2014-09-21 12:00	2014-10-02 12:00	2014-09-21 12:00	2014-10-02 12:00	2015-01-03 10:00	2015-01-14 10:00		PT_Normal					Gk+98c1glkOi6wD993n9uA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106315	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	950	MARBLE STAIRS	10614	710	500	90	0	25	25	90	0	0	0				2015-01-03 10:00	2015-01-15 12:00		2014-09-21 12:00	2014-10-04 14:00	2014-09-21 12:00	2014-10-04 14:00	2014-09-21 12:00	2014-10-04 14:00	2015-01-03 10:00	2015-01-15 12:00		PT_Normal					vkoyan4jqkut5bEf2cpsrQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106316	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	960	FACADES PLASTER DAHARA	10572	0	0	400	0	2300	2300	400	0	0	0				2014-11-22 08:00	2015-01-18 16:00		2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00		PT_Normal					lqYeuNfPE0OICeFmbtAB+Q				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106317	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	970	BARGOLAS	10594	0	0	50	0	1	1	50	0	0	0				2015-01-19 08:00	2015-01-26 10:00		2015-01-19 08:00	2015-01-26 10:00	2015-01-19 08:00	2015-01-26 10:00	2015-01-19 08:00	2015-01-26 10:00	2015-01-19 08:00	2015-01-26 10:00		PT_Normal					BKiqSD02qkaLrjldIh8K4Q				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106318	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	980	INTIAL SAINTARY WORK	10596	0	0	70	0	23	23	70	0	0	0				2014-02-03 08:00	2014-02-12 14:00		2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00		PT_Normal					W5XGqIy5AUeG1NHnIEFCIw				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106319	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	990	FINAL SAINTARY WORK	10596	2330	70	30	0	37	37	30	0	0	0				2015-01-26 10:00	2015-01-29 16:00		2014-02-20 08:00	2014-02-24 14:00	2014-02-20 08:00	2014-02-24 14:00	2014-02-20 08:00	2014-02-24 14:00	2015-01-26 10:00	2015-01-29 16:00		PT_Normal					D6JOzigd7UuGB0PmtUZIlQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106320	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1000	INTIAL SAINTARY WORK	10596	50	50	70	0	24	24	70	0	0	0				2014-02-23 12:00	2014-03-05 10:00		2014-02-16 10:00	2014-02-25 16:00	2014-02-16 10:00	2014-02-25 16:00	2014-02-16 10:00	2014-02-25 16:00	2014-02-23 12:00	2014-03-05 10:00		PT_Normal					z/9cNc4Q1ES+mxETrw1wYg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106321	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1010	FINAL SAINTARY WORK	10596	2260	170	30	0	10	10	30	0	0	0				2015-01-31 08:00	2015-02-03 14:00		2014-03-06 12:00	2014-03-11 10:00	2014-03-06 12:00	2014-03-11 10:00	2014-03-06 12:00	2014-03-11 10:00	2015-01-31 08:00	2015-02-03 14:00		PT_Normal					0oHZOe1v7EWH6K7xKA0dhQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106322	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1020	INTIAL SAINTARY WORK	10596	90	0	70	0	24	24	70	0	0	0				2014-03-24 12:00	2014-04-03 10:00		2014-03-11 10:00	2014-03-20 16:00	2014-03-11 10:00	2014-03-20 16:00	2014-03-11 10:00	2014-03-20 16:00	2014-03-24 12:00	2014-04-03 10:00		PT_Normal					cXJwxL224k2tEUIvwmAddg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106323	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1030	FINAL SAINTARY WORK	10596	2090	130	30	0	10	10	30	0	0	0				2015-02-03 14:00	2015-02-08 12:00		2014-04-05 12:00	2014-04-09 10:00	2014-04-05 12:00	2014-04-09 10:00	2014-04-05 12:00	2014-04-09 10:00	2015-02-03 14:00	2015-02-08 12:00		PT_Normal					MKkFqoQQLUmGCC6HigT8sw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106324	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1040	INTIAL SAINTARY WORK	10596	180	0	70	0	24	24	70	0	0	0				2014-04-29 14:00	2014-05-10 12:00		2014-04-03 10:00	2014-04-13 16:00	2014-04-03 10:00	2014-04-13 16:00	2014-04-03 10:00	2014-04-13 16:00	2014-04-29 14:00	2014-05-10 12:00		PT_Normal					iIVNRE6N/E6iA320crXD9Q				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106325	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1050	FINAL SAINTARY WORK	10596	1960	150	30	0	10	10	30	0	0	0				2015-02-08 12:00	2015-02-12 10:00		2014-04-28 12:00	2014-05-03 10:00	2014-04-28 12:00	2014-05-03 10:00	2014-04-28 12:00	2014-05-03 10:00	2015-02-08 12:00	2015-02-12 10:00		PT_Normal					Zwxu53D/5EC/XtDwf7A3vg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106326	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1060	INTIAL SAINTARY WORK	10596	270	0	70	0	24	24	70	0	0	0				2014-06-07 10:00	2014-06-16 16:00		2014-04-28 12:00	2014-05-08 10:00	2014-04-28 12:00	2014-05-08 10:00	2014-04-28 12:00	2014-05-08 10:00	2014-06-07 10:00	2014-06-16 16:00		PT_Normal					kR5advTz7kW7gpeEvr7mug				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106327	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1070	FINAL SAINTARY WORK	10596	1810	0	30	0	10	10	30	0	0	0				2015-02-12 10:00	2015-02-16 16:00		2014-05-25 08:00	2014-05-28 14:00	2014-05-25 08:00	2014-05-28 14:00	2014-05-25 08:00	2014-05-28 14:00	2015-02-12 10:00	2015-02-16 16:00		PT_Normal					BdX190DlzEGXqnDqvGpkOQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106328	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1080	INTIAL SAINTARY WORK	10596	470	470	30	0	7	7	30	0	0	0				2014-07-16 08:00	2014-07-20 14:00		2014-05-08 10:00	2014-05-12 16:00	2014-05-08 10:00	2014-05-12 16:00	2014-05-08 10:00	2014-05-12 16:00	2014-07-16 08:00	2014-07-20 14:00		PT_Normal					shcQokHDKU2D5C8to3UUEQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106329	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1090	FINAL SAINTARY WORK	10596	1810	0	20	0	5	5	20	0	0	0				2015-02-17 08:00	2015-02-19 12:00		2014-05-28 14:00	2014-06-01 10:00	2014-05-28 14:00	2014-06-01 10:00	2014-05-28 14:00	2014-06-01 10:00	2015-02-17 08:00	2015-02-19 12:00		PT_Normal					ZGN0yku1F0GLUGMjbgkE5w				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106330	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1100	1ST ELECTRICAL FIX	10600	490	40	100	0	300	300	100	0	0	0				2014-05-05 14:00	2014-05-20 10:00		2014-02-23 12:00	2014-03-09 16:00	2014-02-23 12:00	2014-03-09 16:00	2014-02-23 12:00	2014-03-09 16:00	2014-05-05 14:00	2014-05-20 10:00		PT_Normal					LD7DjfISLEeBBuESG6AaVw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106331	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1110	2ND ELECTRICAL FIX	10600	600	150	50	0	65	65	50	0	0	0				2014-06-01 10:00	2014-06-08 12:00		2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-06-01 10:00	2014-06-08 12:00		PT_Normal					GF5+9EjwHUysij6Y80sr4A				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106332	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1120	FINAL ELECTRICAL FIX	10600	1050	290	70	0	24.5	24.5	70	0	0	0				2014-11-08 14:00	2014-11-18 12:00		2014-06-08 12:00	2014-06-18 10:00	2014-06-08 12:00	2014-06-18 10:00	2014-06-08 12:00	2014-06-18 10:00	2014-11-08 14:00	2014-11-18 12:00		PT_Normal					5Jw687XwYEqewIRck+GKvg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106333	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1130	1ST ELECTRICAL FIX	10600	450	40	100	0	80	80	100	0	0	0				2014-05-20 10:00	2014-06-03 14:00		2014-03-16 08:00	2014-03-30 12:00	2014-03-16 08:00	2014-03-30 12:00	2014-03-16 08:00	2014-03-30 12:00	2014-05-20 10:00	2014-06-03 14:00		PT_Normal					Qcz4y9HIZEmtoKiY/Cqoxg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106334	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1140	2ND ELECTRICAL FIX	10600	450	0	50	0	65	65	50	0	0	0				2014-06-08 12:00	2014-06-15 14:00		2014-04-03 10:00	2014-04-10 12:00	2014-04-03 10:00	2014-04-10 12:00	2014-04-03 10:00	2014-04-10 12:00	2014-06-08 12:00	2014-06-15 14:00		PT_Normal					JzWOgnyh8UmMyxDrPy41iw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106335	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1160	FINAL ELECTRICAL FIX	10600	760	220	100	0	160	160	100	0	0	0				2014-11-18 12:00	2014-12-02 16:00		2014-07-30 12:00	2014-08-13 16:00	2014-07-30 12:00	2014-08-13 16:00	2014-07-30 12:00	2014-08-13 16:00	2014-11-18 12:00	2014-12-02 16:00		PT_Normal					sNHc1sMVrEi+X26Gon1svA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106336	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1170	1ST ELECTRICAL FIX	10600	410	40	100	0	85	85	100	0	0	0				2014-06-03 14:00	2014-06-18 10:00		2014-04-05 12:00	2014-04-19 16:00	2014-04-05 12:00	2014-04-19 16:00	2014-04-05 12:00	2014-04-19 16:00	2014-06-03 14:00	2014-06-18 10:00		PT_Normal					VvD5hVshZkWoLc8iA8Z6eA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106337	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1180	2ND ELECTRICAL FIX	10600	330	0	50	0	70	70	50	0	0	0				2014-06-26 14:00	2014-07-03 16:00		2014-05-10 12:00	2014-05-17 14:00	2014-05-10 12:00	2014-05-17 14:00	2014-05-10 12:00	2014-05-17 14:00	2014-06-26 14:00	2014-07-03 16:00		PT_Normal					xuUI3V3FWUajjh0UTrsKwQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106338	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1190	FINAL ELECTRICAL FIX	10600	540	120	100	0	75	75	100	0	0	0				2014-12-03 08:00	2014-12-17 12:00		2014-09-15 12:00	2014-09-29 16:00	2014-09-15 12:00	2014-09-29 16:00	2014-09-15 12:00	2014-09-29 16:00	2014-12-03 08:00	2014-12-17 12:00		PT_Normal					wfnban+RQUe0CrQO+X5kcA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106339	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1200	1ST ELECTRICAL FIX	10600	370	60	100	0	90	90	100	0	0	0				2014-06-18 10:00	2014-07-02 14:00		2014-04-26 08:00	2014-05-10 12:00	2014-04-26 08:00	2014-05-10 12:00	2014-04-26 08:00	2014-05-10 12:00	2014-06-18 10:00	2014-07-02 14:00		PT_Normal					iiFnC+eFtEuTo6F5B01olA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106340	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1210	2ND ELECTRICAL FIX	10600	290	0	50	0	75	75	50	0	0	0				2014-07-29 10:00	2014-08-05 12:00		2014-06-17 08:00	2014-06-24 10:00	2014-06-17 08:00	2014-06-24 10:00	2014-06-17 08:00	2014-06-24 10:00	2014-07-29 10:00	2014-08-05 12:00		PT_Normal					SSW7lmRGMkiytpc/Hqnd7A				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106341	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1220	FINAL ELECTRICAL FIX	10600	420	210	100	0	80	80	100	0	0	0				2014-12-17 12:00	2014-12-31 16:00		2014-10-18 08:00	2014-11-01 12:00	2014-10-18 08:00	2014-11-01 12:00	2014-10-18 08:00	2014-11-01 12:00	2014-12-17 12:00	2014-12-31 16:00		PT_Normal					6j8x38U4VkO81wCrvAq5Rg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106342	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1230	1ST ELECTRICAL FIX	10600	310	0	100	0	90	90	100	0	0	0				2014-07-02 14:00	2014-07-17 10:00		2014-05-19 08:00	2014-06-02 12:00	2014-05-19 08:00	2014-06-02 12:00	2014-05-19 08:00	2014-06-02 12:00	2014-07-02 14:00	2014-07-17 10:00		PT_Normal					kJX49SYwLECxarB7qJJZeQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106343	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1240	2ND ELECTRICAL FIX	10600	210	0	50	0	75	75	50	0	0	0				2014-08-20 08:00	2014-08-27 10:00		2014-07-20 14:00	2014-07-27 16:00	2014-07-20 14:00	2014-07-27 16:00	2014-07-20 14:00	2014-07-27 16:00	2014-08-20 08:00	2014-08-27 10:00		PT_Normal					D2cVYpFHTEa2Eq11rxAO1w				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106344	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1250	FINAL ELECTRICAL FIX	10600	210	0	100	0	80	80	100	0	0	0				2015-01-01 08:00	2015-01-15 12:00		2014-12-01 14:00	2014-12-16 10:00	2014-12-01 14:00	2014-12-16 10:00	2014-12-01 14:00	2014-12-16 10:00	2015-01-01 08:00	2015-01-15 12:00		PT_Normal					LaJD525lN0uS7CEhB+EsBg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106345	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1260	1ST ELECTRICAL FIX	10600	310	0	100	0	50	50	100	0	0	0				2014-07-17 10:00	2014-07-31 14:00		2014-06-02 12:00	2014-06-16 16:00	2014-06-02 12:00	2014-06-16 16:00	2014-06-02 12:00	2014-06-16 16:00	2014-07-17 10:00	2014-07-31 14:00		PT_Normal					hF+pxF/YDUqjGLvA9zhEiw				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106346	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1270	2ND ELECTRICAL FIX	10600	290	0	50	0	35	35	50	0	0	0				2014-09-13 08:00	2014-09-20 10:00		2014-07-31 14:00	2014-08-07 16:00	2014-07-31 14:00	2014-08-07 16:00	2014-07-31 14:00	2014-08-07 16:00	2014-09-13 08:00	2014-09-20 10:00		PT_Normal					5za8/l37/kaZn+GIEwgU2g				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106347	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1280	FINAL ELECTRICAL FIX	10600	210	210	70	0	34	34	70	0	0	0				2015-01-15 12:00	2015-01-26 10:00		2014-12-16 10:00	2014-12-25 16:00	2014-12-16 10:00	2014-12-25 16:00	2014-12-16 10:00	2014-12-25 16:00	2015-01-15 12:00	2015-01-26 10:00		PT_Normal					SztbWlLUE0OIBbdOjeOaEg				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106348	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1290	1ST ELECTRICAL FIX	10600	310	0	100	0	31	31	100	0	0	0				2014-07-31 14:00	2014-08-16 10:00		2014-06-17 08:00	2014-07-01 12:00	2014-06-17 08:00	2014-07-01 12:00	2014-06-17 08:00	2014-07-01 12:00	2014-07-31 14:00	2014-08-16 10:00		PT_Normal					QXKZkNVGjkmY6kKe6mbk1A				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106349	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1300	2ND ELECTRICAL FIX	10600	500	0	50	0	16	16	50	0	0	0				2014-11-06 12:00	2014-11-13 14:00		2014-08-26 08:00	2014-09-02 10:00	2014-08-26 08:00	2014-09-02 10:00	2014-08-26 08:00	2014-09-02 10:00	2014-11-06 12:00	2014-11-13 14:00		PT_Normal					KK2KPRTVDUuMx8rTmpgUWQ				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106350	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1310	FINAL ELECTRICAL FIX	10600	0	0	100	0	21	21	100	0	0	0				2015-01-26 10:00	2015-02-09 14:00		2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00		PT_Normal					0ZVMGt6g70CRCBfmpJM/qQ				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106351	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1320	1ST ELECTRICAL FIX	10600	310	310	70	0	25	25	70	0	0	0				2014-08-16 10:00	2014-08-25 16:00		2014-07-01 12:00	2014-07-12 10:00	2014-07-01 12:00	2014-07-12 10:00	2014-07-01 12:00	2014-07-12 10:00	2014-08-16 10:00	2014-08-25 16:00		PT_Normal					205fQ8+MmkaVovcaqkrF+Q				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106352	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1330	2ND ELECTRICAL FIX	10600	0	0	50	0	19	19	50	0	0	0				2014-11-13 14:00	2014-11-20 16:00		2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00		PT_Normal					rCof04aRZk2Tu9Y1A4FF8g				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106353	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1340	FINAL ELECTRICAL FIX	10600	510	510	40	0	12	12	40	0	0	0				2015-02-03 14:00	2015-02-09 14:00		2014-11-22 08:00	2014-11-26 16:00	2014-11-22 08:00	2014-11-26 16:00	2014-11-22 08:00	2014-11-26 16:00	2015-02-03 14:00	2015-02-09 14:00		PT_Normal					OW0xb/XVvUahEj3MN6YGzA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106354	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1350	ELEVATOR		0	0	70	0	0	0	70	0	0	0				2015-02-09 14:00	2015-02-19 12:00		2015-02-09 14:00	2015-02-19 12:00	2015-02-09 14:00	2015-02-19 12:00	2015-02-09 14:00	2015-02-19 12:00	2015-02-09 14:00	2015-02-19 12:00		PT_Normal					5Q5KZ5bSJE6iV2VMzSglrA				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106355	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1360	final fisihes closeout		170	170	0	0	0	0	0	0	0	0				2015-02-19 12:00	2015-02-19 12:00		2015-01-26 10:00	2015-01-26 10:00	2015-01-26 10:00	2015-01-26 10:00	2015-01-26 10:00	2015-01-26 10:00	2015-02-19 12:00	2015-02-19 12:00		PT_Normal					M330k1SbUEKO7Rdz8TUpog				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106356	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1370	mechincal closeout		1810	1810	0	0	0	0	0	0	0	0				2015-02-19 12:00	2015-02-19 12:00		2014-06-01 10:00	2014-06-01 10:00	2014-06-01 10:00	2014-06-01 10:00	2014-06-01 10:00	2014-06-01 10:00	2015-02-19 12:00	2015-02-19 12:00		PT_Normal					xar5r4ILIEufiAFXhCcViA				N	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106357	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1380	electrical closeout		0	0	0	0	0	0	0	0	0	0				2015-02-09 14:00	2015-02-09 14:00		2015-02-09 14:00	2015-02-09 14:00	2015-02-09 14:00	2015-02-09 14:00	2015-02-09 14:00	2015-02-09 14:00	2015-02-09 14:00	2015-02-09 14:00		PT_Normal					o8Zmtjrw90mrmSUY23xpsQ				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106358	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDUR2	TK_NotStart	1390	confeying closeout		0	0	0	0	0	0	0	0	0	0				2015-02-19 12:00	2015-02-19 12:00		2015-02-19 12:00	2015-02-19 12:00	2015-02-19 12:00	2015-02-19 12:00	2015-02-19 12:00	2015-02-19 12:00	2015-02-19 12:00	2015-02-19 12:00		PT_Normal					1rjkyrTMykeZI3YIjI6vHg				Y	0	0			2013-08-03 16:51	2013-09-14 22:01	admin	admin	
+%R	106559	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Mile	DT_FixedDrtn	TK_NotStart	1400	PROJECT START				0	0	0	0	0	0	0	0				2013-08-03 08:00	2013-08-03 08:00		2013-08-03 00:00	2013-08-03 00:00	2013-08-03 08:00	2013-08-03 08:00	2013-08-03 08:00	2013-08-03 08:00	2013-08-03 08:00	2013-08-03 08:00		PT_Normal					EpCnxBh0XkW5H9+2ClR3kA	NdRv+yWCW0G656oEZI330w			Y	0	0			2013-08-10 20:23	2013-09-14 22:09	admin	admin	
+%R	106560	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1410	R.C SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-09-25 08:00	2013-10-02 10:00		2013-08-03 08:00	2013-08-10 10:00	2013-08-03 08:00	2013-08-10 10:00	2013-08-03 08:00	2013-08-10 10:00	2013-09-25 08:00	2013-10-02 10:00		PT_Normal					6hL4JwevFUiqiiZvktoTXg	EpCnxBh0XkW5H9+2ClR3kA			N	0	0			2013-08-10 20:26	2013-09-14 22:01	admin	admin	
+%R	106561	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1420	R.C SHOPDRAWING APPROVAL		440	440	50	0	0	0	50	0	0	0				2013-10-14 10:00	2013-10-21 12:00		2013-08-10 10:00	2013-08-17 12:00	2013-08-10 10:00	2013-08-17 12:00	2013-08-10 10:00	2013-08-17 12:00	2013-10-14 10:00	2013-10-21 12:00		PT_Normal					H6Pw3HWBxEKEeUCFxT4QEA	6hL4JwevFUiqiiZvktoTXg			N	0	0			2013-08-10 20:28	2013-09-14 22:01	admin	admin	
+%R	106564	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1450	B.COL. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-10-02 10:00	2013-10-09 12:00		2013-08-10 10:00	2013-08-17 12:00	2013-08-10 10:00	2013-08-17 12:00	2013-08-10 10:00	2013-08-17 12:00	2013-10-02 10:00	2013-10-09 12:00		PT_Normal					cyXTc6we5E2U1om7gkJRyw	8WkPRk4NN0i9moBz9E+BdA			N	0	0			2013-08-10 20:33	2013-09-14 22:01	admin	admin	
+%R	106565	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1460	B.COL SHOPDRAWING APPROVAL		710	710	50	0	0	0	50	0	0	0				2013-12-01 10:00	2013-12-08 12:00		2013-08-17 12:00	2013-08-24 14:00	2013-08-17 12:00	2013-08-24 14:00	2013-08-17 12:00	2013-08-24 14:00	2013-12-01 10:00	2013-12-08 12:00		PT_Normal					fuFvtcTcbECYB3Jk5E7hOQ	cyXTc6we5E2U1om7gkJRyw			N	0	0			2013-08-10 20:35	2013-09-14 22:01	admin	admin	
+%R	106566	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1470	GR.COL. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-10-16 14:00	2013-10-23 16:00		2013-08-24 14:00	2013-08-31 16:00	2013-08-24 14:00	2013-08-31 16:00	2013-08-24 14:00	2013-08-31 16:00	2013-10-16 14:00	2013-10-23 16:00		PT_Normal					7C8nxGqxxk2u3W0y2LxUAQ	cyXTc6we5E2U1om7gkJRyw			N	0	0			2013-08-10 20:35	2013-09-14 22:01	admin	admin	
+%R	106567	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1480	GR.COL SHOPDRAWING APPROVAL		780	780	50	0	0	0	50	0	0	0				2013-12-26 12:00	2014-01-02 14:00		2013-09-01 08:00	2013-09-09 10:00	2013-09-01 08:00	2013-09-09 10:00	2013-09-01 08:00	2013-09-09 10:00	2013-12-26 12:00	2014-01-02 14:00		PT_Normal					s68XjswhGEucHa4+uczj3Q	fuFvtcTcbECYB3Jk5E7hOQ			N	0	0			2013-08-10 20:35	2013-09-14 22:01	admin	admin	
+%R	106568	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1490	1ST COL. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-10-31 10:00	2013-11-07 12:00		2013-09-09 10:00	2013-09-16 12:00	2013-09-09 10:00	2013-09-16 12:00	2013-09-09 10:00	2013-09-16 12:00	2013-10-31 10:00	2013-11-07 12:00		PT_Normal					nmFKW4zM60qsSYdTbk11ew	7C8nxGqxxk2u3W0y2LxUAQ			N	0	0			2013-08-10 20:36	2013-09-14 22:01	admin	admin	
+%R	106569	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1500	1ST COL SHOPDRAWING APPROVAL		950	860	50	0	0	0	50	0	0	0				2014-02-04 10:00	2014-02-11 12:00		2013-09-16 12:00	2013-09-23 14:00	2013-09-16 12:00	2013-09-23 14:00	2013-09-16 12:00	2013-09-23 14:00	2014-02-04 10:00	2014-02-11 12:00		PT_Normal					ahAoMcZ+/02HdOm3Sg1fwQ	s68XjswhGEucHa4+uczj3Q			N	0	0			2013-08-10 20:36	2013-09-14 22:01	admin	admin	
+%R	106570	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1510	2ND COL. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-11-14 14:00	2013-11-21 16:00		2013-09-23 14:00	2013-09-30 16:00	2013-09-23 14:00	2013-09-30 16:00	2013-09-23 14:00	2013-09-30 16:00	2013-11-14 14:00	2013-11-21 16:00		PT_Normal					ea/r3Ev8k0OYZt8oSwGcAg	nmFKW4zM60qsSYdTbk11ew			N	0	0			2013-08-10 20:38	2013-09-14 22:01	admin	admin	
+%R	106571	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1520	2ND COL SHOPDRAWING APPROVAL		360	0	50	0	0	0	50	0	0	0				2013-11-23 08:00	2013-12-01 10:00		2013-10-01 08:00	2013-10-08 10:00	2013-10-01 08:00	2013-10-08 10:00	2013-10-01 08:00	2013-10-08 10:00	2013-11-23 08:00	2013-12-01 10:00		PT_Normal					s/b0mLCYdESvMEaB4WBabg	ahAoMcZ+/02HdOm3Sg1fwQ			N	0	0			2013-08-10 20:38	2013-09-14 22:01	admin	admin	
+%R	106572	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1530	3RD COL. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-12-08 12:00	2013-12-15 14:00		2013-10-15 12:00	2013-10-22 14:00	2013-10-15 12:00	2013-10-22 14:00	2013-10-15 12:00	2013-10-22 14:00	2013-12-08 12:00	2013-12-15 14:00		PT_Normal					3+XbHfSlKUOWts+nAsIjzQ	ea/r3Ev8k0OYZt8oSwGcAg			N	0	0			2013-08-10 20:39	2013-09-14 22:01	admin	admin	
+%R	106573	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1540	3RD CO. SHOPDRAWING APPROVAL		1220	950	50	0	0	0	50	0	0	0				2014-04-21 10:00	2014-04-28 12:00		2013-10-22 14:00	2013-10-29 16:00	2013-10-22 14:00	2013-10-29 16:00	2013-10-22 14:00	2013-10-29 16:00	2014-04-21 10:00	2014-04-28 12:00		PT_Normal					f6ijXzE/OkGqPQlSNtdIMg	s/b0mLCYdESvMEaB4WBabg			N	0	0			2013-08-10 20:39	2013-09-14 22:01	admin	admin	
+%R	106574	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1550	ROOF COL. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-12-23 08:00	2013-12-31 10:00		2013-10-30 08:00	2013-11-06 10:00	2013-10-30 08:00	2013-11-06 10:00	2013-10-30 08:00	2013-11-06 10:00	2013-12-23 08:00	2013-12-31 10:00		PT_Normal					2iy4YR/Od02VoQm6LiThmQ	3+XbHfSlKUOWts+nAsIjzQ			N	0	0			2013-08-10 20:39	2013-09-14 22:01	admin	admin	
+%R	106575	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1560	ROOF COL. SHOPDRAWING APPROVAL		1480	1020	50	0	0	0	50	0	0	0				2014-06-12 10:00	2014-06-19 12:00		2013-11-06 10:00	2013-11-13 12:00	2013-11-06 10:00	2013-11-13 12:00	2013-11-06 10:00	2013-11-13 12:00	2014-06-12 10:00	2014-06-19 12:00		PT_Normal					+TX4LPlsyUqB98bZ7W+Wpw	f6ijXzE/OkGqPQlSNtdIMg			N	0	0			2013-08-10 20:39	2013-09-14 22:01	admin	admin	
+%R	106576	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1570	ISOLATION MATERIAL SUBMITAL		3300	3300	50	0	0	0	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2013-10-16 14:00	2013-10-24 08:00	2013-10-16 14:00	2013-10-24 08:00	2013-10-16 14:00	2013-10-24 08:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					vmLIyhIhLEG24CYaZfQ/VQ	+TX4LPlsyUqB98bZ7W+Wpw			N	0	0			2013-08-10 20:44	2013-09-14 22:01	admin	admin	
+%R	106577	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1580	ISOLATION MATERIAL APPROVAL		3100	0	50	0	0	0	50	0	0	0				2015-01-21 12:00	2015-01-28 14:00		2013-10-24 08:00	2013-10-31 10:00	2013-10-24 08:00	2013-10-31 10:00	2013-10-24 08:00	2013-10-31 10:00	2015-01-21 12:00	2015-01-28 14:00		PT_Normal					TuacrGbDr0WRWtKa32jmaA	vmLIyhIhLEG24CYaZfQ/VQ			N	0	0			2013-08-10 20:45	2013-09-14 22:01	admin	admin	
+%R	106578	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1590	ISOLATION MATERIAL PROCURMENT		3100	0	50	0	0	0	50	0	0	0				2015-01-28 14:00	2015-02-04 16:00		2013-10-31 10:00	2013-11-07 12:00	2013-10-31 10:00	2013-11-07 12:00	2013-10-31 10:00	2013-11-07 12:00	2015-01-28 14:00	2015-02-04 16:00		PT_Normal					qw1HsYouLU6xaWn1rnFCcA	TuacrGbDr0WRWtKa32jmaA			N	0	0			2013-08-10 20:46	2013-09-14 22:01	admin	admin	
+%R	106579	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1600	ISOLATION MATERIAL PROCURMENT		3100	0	100	0	0	0	100	0	0	0				2015-02-04 16:00	2015-02-19 12:00		2013-11-07 12:00	2013-11-23 08:00	2013-11-07 12:00	2013-11-23 08:00	2013-11-07 12:00	2013-11-23 08:00	2015-02-04 16:00	2015-02-19 12:00		PT_Normal					NGECyq34c0yW5SZeRV9gQw	qw1HsYouLU6xaWn1rnFCcA			N	0	0			2013-08-10 20:47	2013-09-14 22:01	admin	admin	
+%R	106580	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1610	BRICK MATERIAL SUBMITAL		3100	0	50	0	0	0	50	0	0	0				2015-01-28 14:00	2015-02-04 16:00		2013-10-31 10:00	2013-11-07 12:00	2013-10-31 10:00	2013-11-07 12:00	2013-10-31 10:00	2013-11-07 12:00	2015-01-28 14:00	2015-02-04 16:00		PT_Normal					DrgmoWCzJkG8VUTpV5ekfg	vmLIyhIhLEG24CYaZfQ/VQ			N	0	0			2013-08-10 20:48	2013-09-14 22:01	admin	admin	
+%R	106581	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1620	BRICK MATERIAL APPROVAL		3430	330	50	0	0	0	50	0	0	0				2015-02-04 16:00	2015-02-12 10:00		2013-09-21 10:00	2013-09-28 12:00	2013-09-21 10:00	2013-09-28 12:00	2013-09-21 10:00	2013-09-28 12:00	2015-02-04 16:00	2015-02-12 10:00		PT_Normal					bjPACwvIvE6c0evKGYczFg	TuacrGbDr0WRWtKa32jmaA			N	0	0			2013-08-10 20:48	2013-09-14 22:01	admin	admin	
+%R	106582	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1630	BRICK MATERIAL PROCURMENT		3430	0	50	0	0	0	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2013-09-28 12:00	2013-10-05 14:00	2013-09-28 12:00	2013-10-05 14:00	2013-09-28 12:00	2013-10-05 14:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					0HWCKclb7UmgZLGXkcgrZQ	qw1HsYouLU6xaWn1rnFCcA			N	0	0			2013-08-10 20:48	2013-09-14 22:01	admin	admin	
+%R	106583	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1640	BRICK MATERIAL DELIEVERY		3130	0	300	0	0	0	300	0	0	0				2015-01-07 08:00	2015-02-19 12:00		2013-10-05 14:00	2013-11-18 10:00	2013-10-05 14:00	2013-11-18 10:00	2013-10-05 14:00	2013-11-18 10:00	2015-01-07 08:00	2015-02-19 12:00		PT_Normal					mBgQUzy6LEGB8P3drco3rg	NGECyq34c0yW5SZeRV9gQw			N	0	0			2013-08-10 20:48	2013-09-14 22:01	admin	admin	
+%R	106584	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1650	CERMIC MATERIAL SUBMITAL		3100	2180	50	0	0	0	50	0	0	0				2015-02-05 08:00	2015-02-12 10:00		2013-11-07 12:00	2013-11-14 14:00	2013-11-07 12:00	2013-11-14 14:00	2013-11-07 12:00	2013-11-14 14:00	2015-02-05 08:00	2015-02-12 10:00		PT_Normal					AteGeO1CCkmDG+fYV6GNUA	DrgmoWCzJkG8VUTpV5ekfg			N	0	0			2013-08-10 20:50	2013-09-14 22:01	admin	admin	
+%R	106585	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1660	CERMIC MATERIAL APPROVAL		3200	100	50	0	0	0	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2013-10-31 10:00	2013-11-07 12:00	2013-10-31 10:00	2013-11-07 12:00	2013-10-31 10:00	2013-11-07 12:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					u6iVJZ8+PECsIkGD2XHPLg	bjPACwvIvE6c0evKGYczFg			N	0	0			2013-08-10 20:50	2013-09-14 22:01	admin	admin	
+%R	106586	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1670	CERMIC MATERIAL PROCURMENT		3150	0	50	0	0	0	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2013-11-07 12:00	2013-11-14 14:00	2013-11-07 12:00	2013-11-14 14:00	2013-11-07 12:00	2013-11-14 14:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					6y1mtxhsL0yeBURLsclSVg	0HWCKclb7UmgZLGXkcgrZQ			N	0	0			2013-08-10 20:50	2013-09-14 22:01	admin	admin	
+%R	106587	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1680	CERMIC MATERIAL DELIEVERY		2550	0	600	0	0	0	600	0	0	0				2014-11-24 12:00	2015-02-19 12:00		2013-11-14 14:00	2014-02-12 14:00	2013-11-14 14:00	2014-02-12 14:00	2013-11-14 14:00	2014-02-12 14:00	2014-11-24 12:00	2015-02-19 12:00		PT_Normal					d9PHsrsjgkyQ/jT5POQR7Q	mBgQUzy6LEGB8P3drco3rg			N	0	0			2013-08-10 20:50	2013-09-14 22:01	admin	admin	
+%R	106588	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1690	RED TILES MATERIAL SUBMITAL		920	920	50	0	0	0	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2014-10-01 10:00	2014-10-08 12:00	2014-10-01 10:00	2014-10-08 12:00	2014-10-01 10:00	2014-10-08 12:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					WZFir9K8jE2Ij6VyQSzEVg	AteGeO1CCkmDG+fYV6GNUA			N	0	0			2013-08-10 20:54	2013-09-14 22:01	admin	admin	
+%R	106589	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1700	RED TILES MATERIAL APPROVAL		870	0	50	0	0	0	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2014-10-08 12:00	2014-10-15 14:00	2014-10-08 12:00	2014-10-15 14:00	2014-10-08 12:00	2014-10-15 14:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					nGLwc/K7j0uwzvaqoUZODA	u6iVJZ8+PECsIkGD2XHPLg			N	0	0			2013-08-10 20:54	2013-09-14 22:01	admin	admin	
+%R	106590	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1710	RED TILES MATERIAL PROCURMENT		820	0	50	0	0	0	50	0	0	0				2015-02-12 10:00	2015-02-19 12:00		2014-10-15 14:00	2014-10-23 08:00	2014-10-15 14:00	2014-10-23 08:00	2014-10-15 14:00	2014-10-23 08:00	2015-02-12 10:00	2015-02-19 12:00		PT_Normal					e0037MDgN0yeIDe6ZyWYgA	6y1mtxhsL0yeBURLsclSVg			N	0	0			2013-08-10 20:54	2013-09-14 22:01	admin	admin	
+%R	106591	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1720	RED TILES MATERIAL DELIEVERY		670	0	150	0	0	0	150	0	0	0				2015-01-28 14:00	2015-02-19 12:00		2014-10-23 08:00	2014-11-13 14:00	2014-10-23 08:00	2014-11-13 14:00	2014-10-23 08:00	2014-11-13 14:00	2015-01-28 14:00	2015-02-19 12:00		PT_Normal					MGgYJo5LTkeuhGcMBBki1w	d9PHsrsjgkyQ/jT5POQR7Q			N	0	0			2013-08-10 20:54	2013-09-14 22:01	admin	admin	
+%R	106592	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1730	MOBILZATION		0	0	300	0	0	0	300	0	0	0				2013-08-03 08:00	2013-09-16 12:00		2013-08-03 08:00	2013-09-16 12:00	2013-08-03 08:00	2013-09-16 12:00	2013-08-03 08:00	2013-09-16 12:00	2013-08-03 08:00	2013-09-16 12:00		PT_Normal					Kk+7Janv8kaOVxbgNq6yrg	EpCnxBh0XkW5H9+2ClR3kA			Y	0	0			2013-08-10 20:57	2013-09-14 22:01	admin	admin	
+%R	106767	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1740	B.SLAB SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-10-09 12:00	2013-10-16 14:00		2013-08-17 12:00	2013-08-24 14:00	2013-08-17 12:00	2013-08-24 14:00	2013-08-17 12:00	2013-08-24 14:00	2013-10-09 12:00	2013-10-16 14:00		PT_Normal					aT62xghpIkq0IkitLwPyIg	cyXTc6we5E2U1om7gkJRyw			N	0	0			2013-08-12 20:42	2013-09-14 22:01	admin	admin	
+%R	106768	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1750	B.SLAB SHOPDRAWING APPROVAL		730	730	50	0	0	0	50	0	0	0				2013-12-11 08:00	2013-12-18 10:00		2013-08-24 14:00	2013-08-31 16:00	2013-08-24 14:00	2013-08-31 16:00	2013-08-24 14:00	2013-08-31 16:00	2013-12-11 08:00	2013-12-18 10:00		PT_Normal					QDc1arRvRE2tWwsjOZN96Q	fuFvtcTcbECYB3Jk5E7hOQ			N	0	0			2013-08-12 20:42	2013-09-14 22:01	admin	admin	
+%R	106769	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1760	GR.SLAB SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-10-24 08:00	2013-10-31 10:00		2013-09-01 08:00	2013-09-09 10:00	2013-09-01 08:00	2013-09-09 10:00	2013-09-01 08:00	2013-09-09 10:00	2013-10-24 08:00	2013-10-31 10:00		PT_Normal					Lt97R4he60ub/thxWe5gwQ	7C8nxGqxxk2u3W0y2LxUAQ			N	0	0			2013-08-12 21:07	2013-09-14 22:01	admin	admin	
+%R	106770	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1770	GR.SLAB SHOPDRAWING APPROVAL		800	800	50	0	0	0	50	0	0	0				2014-01-06 10:00	2014-01-13 12:00		2013-09-09 10:00	2013-09-16 12:00	2013-09-09 10:00	2013-09-16 12:00	2013-09-09 10:00	2013-09-16 12:00	2014-01-06 10:00	2014-01-13 12:00		PT_Normal					1E7o9nwmJ0umlCCLajeAyQ	s68XjswhGEucHa4+uczj3Q			N	0	0			2013-08-12 21:07	2013-09-14 22:01	admin	admin	
+%R	106771	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1780	1ST SLAB. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-11-07 12:00	2013-11-14 14:00		2013-09-16 12:00	2013-09-23 14:00	2013-09-16 12:00	2013-09-23 14:00	2013-09-16 12:00	2013-09-23 14:00	2013-11-07 12:00	2013-11-14 14:00		PT_Normal					CTnYZZm210aLw/MCCQJ86Q	nmFKW4zM60qsSYdTbk11ew			N	0	0			2013-08-12 21:07	2013-09-14 22:01	admin	admin	
+%R	106772	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1790	1ST SLAB SHOPDRAWING APPROVAL		970	880	50	0	0	0	50	0	0	0				2014-02-15 08:00	2014-02-22 10:00		2013-09-23 14:00	2013-09-30 16:00	2013-09-23 14:00	2013-09-30 16:00	2013-09-23 14:00	2013-09-30 16:00	2014-02-15 08:00	2014-02-22 10:00		PT_Normal					lvlR2PFvrUWGFawu5fwixw	ahAoMcZ+/02HdOm3Sg1fwQ			N	0	0			2013-08-12 21:07	2013-09-14 22:01	admin	admin	
+%R	106773	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1800	2ND SLAB. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-12-01 10:00	2013-12-08 12:00		2013-10-08 10:00	2013-10-15 12:00	2013-10-08 10:00	2013-10-15 12:00	2013-10-08 10:00	2013-10-15 12:00	2013-12-01 10:00	2013-12-08 12:00		PT_Normal					BA5tsZDsnUGI0wGsEK74qg	ea/r3Ev8k0OYZt8oSwGcAg			N	0	0			2013-08-12 21:08	2013-09-14 22:01	admin	admin	
+%R	106774	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1810	2ND SLAB SHOPDRAWING APPROVAL		1080	900	50	0	0	0	50	0	0	0				2014-03-24 12:00	2014-03-31 14:00		2013-10-15 12:00	2013-10-22 14:00	2013-10-15 12:00	2013-10-22 14:00	2013-10-15 12:00	2013-10-22 14:00	2014-03-24 12:00	2014-03-31 14:00		PT_Normal					Nr0iV7OixUyyfoADZ2G2/w	s/b0mLCYdESvMEaB4WBabg			N	0	0			2013-08-12 21:08	2013-09-14 22:01	admin	admin	
+%R	106775	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1820	3RD SLAB. SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-12-15 14:00	2013-12-22 16:00		2013-10-22 14:00	2013-10-29 16:00	2013-10-22 14:00	2013-10-29 16:00	2013-10-22 14:00	2013-10-29 16:00	2013-12-15 14:00	2013-12-22 16:00		PT_Normal					golF9H2R9km+LCWSkvtKrQ	3+XbHfSlKUOWts+nAsIjzQ			N	0	0			2013-08-12 21:09	2013-09-14 22:01	admin	admin	
+%R	106776	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1830	3RD SLAB SHOPDRAWING APPROVAL		1240	970	50	0	0	0	50	0	0	0				2014-05-01 08:00	2014-05-08 10:00		2013-10-30 08:00	2013-11-06 10:00	2013-10-30 08:00	2013-11-06 10:00	2013-10-30 08:00	2013-11-06 10:00	2014-05-01 08:00	2014-05-08 10:00		PT_Normal					9c/eamMKTECEcvgatAZhMw	f6ijXzE/OkGqPQlSNtdIMg			N	0	0			2013-08-12 21:09	2013-09-14 22:01	admin	admin	
+%R	106777	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1840	ROOF SLAB SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2013-12-31 10:00	2014-01-07 12:00		2013-11-06 10:00	2013-11-13 12:00	2013-11-06 10:00	2013-11-13 12:00	2013-11-06 10:00	2013-11-13 12:00	2013-12-31 10:00	2014-01-07 12:00		PT_Normal					1Xa1/U7PfUi9WiU5PPUUSw	2iy4YR/Od02VoQm6LiThmQ			N	0	0			2013-08-12 21:10	2013-09-14 22:01	admin	admin	
+%R	106778	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1850	ROOF SLAB SHOPDRAWING APPROVAL		360	0	50	0	0	0	50	0	0	0				2014-01-07 12:00	2014-01-14 14:00		2013-11-13 12:00	2013-11-20 14:00	2013-11-13 12:00	2013-11-20 14:00	2013-11-13 12:00	2013-11-20 14:00	2014-01-07 12:00	2014-01-14 14:00		PT_Normal					7mwi0D9a30SgXfGO/6LFwg	+TX4LPlsyUqB98bZ7W+Wpw			N	0	0			2013-08-12 21:10	2013-09-14 22:01	admin	admin	
+%R	106779	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1860	B.MASONARY SHOPDRAWING SUBMITAL		360	0	50	0	0	0	50	0	0	0				2014-01-14 14:00	2014-01-21 16:00		2013-11-20 14:00	2013-11-27 16:00	2013-11-20 14:00	2013-11-27 16:00	2013-11-20 14:00	2013-11-27 16:00	2014-01-14 14:00	2014-01-21 16:00		PT_Normal					7iAwIeb0SUS/yk+lTqMu8A	1Xa1/U7PfUi9WiU5PPUUSw			N	0	0			2013-08-12 21:22	2013-09-14 22:01	admin	admin	
+%R	106780	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1870	B.MASONARY SHOPDRAWING APPROVAL		360	360	50	0	0	0	50	0	0	0				2014-01-22 08:00	2014-01-29 10:00		2013-11-30 08:00	2013-12-07 10:00	2013-11-30 08:00	2013-12-07 10:00	2013-11-30 08:00	2013-12-07 10:00	2014-01-22 08:00	2014-01-29 10:00		PT_Normal					wqdXJeWzM0uf58kBCoaoaQ	7mwi0D9a30SgXfGO/6LFwg			N	0	0			2013-08-12 21:22	2013-09-14 22:01	admin	admin	
+%R	106781	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1880	GR.MASONARY SHOPDRAWING SUBMITAL		390	0	50	0	0	0	50	0	0	0				2014-01-26 14:00	2014-02-02 16:00		2013-11-30 08:00	2013-12-07 10:00	2013-11-30 08:00	2013-12-07 10:00	2013-11-30 08:00	2013-12-07 10:00	2014-01-26 14:00	2014-02-02 16:00		PT_Normal					D324eA70rk6zpkSIt07CYQ	7iAwIeb0SUS/yk+lTqMu8A			N	0	0			2013-08-12 21:26	2013-09-14 22:01	admin	admin	
+%R	106782	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1890	GR.MASONARY SHOPDRAWING APPROVAL		390	340	50	0	0	0	50	0	0	0				2014-02-03 08:00	2014-02-10 10:00		2013-12-07 10:00	2013-12-14 12:00	2013-12-07 10:00	2013-12-14 12:00	2013-12-07 10:00	2013-12-14 12:00	2014-02-03 08:00	2014-02-10 10:00		PT_Normal					zVwzGRKpkkKQVsTtt957SA	wqdXJeWzM0uf58kBCoaoaQ			N	0	0			2013-08-12 21:26	2013-09-14 22:01	admin	admin	
+%R	106783	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1900	1ST.MASONARY SHOPDRAWING SUBMITAL		680	0	50	0	0	0	50	0	0	0				2014-03-17 10:00	2014-03-24 12:00		2013-12-07 10:00	2013-12-14 12:00	2013-12-07 10:00	2013-12-14 12:00	2013-12-07 10:00	2013-12-14 12:00	2014-03-17 10:00	2014-03-24 12:00		PT_Normal					Z38BzSg4C0em/pBJ7XdzLQ	D324eA70rk6zpkSIt07CYQ			N	0	0			2013-08-12 21:28	2013-09-14 22:01	admin	admin	
+%R	106784	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1910	1ST.MASONARY SHOPDRAWING APPROVAL		680	0	50	0	0	0	50	0	0	0				2014-03-24 12:00	2014-03-31 14:00		2013-12-14 12:00	2013-12-21 14:00	2013-12-14 12:00	2013-12-21 14:00	2013-12-14 12:00	2013-12-21 14:00	2014-03-24 12:00	2014-03-31 14:00		PT_Normal					kRFsos6MaUKvbXGIhyxPjg	zVwzGRKpkkKQVsTtt957SA			N	0	0			2013-08-12 21:28	2013-09-14 22:01	admin	admin	
+%R	106785	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1920	2ND.MASONARY SHOPDRAWING SUBMITAL		680	0	50	0	0	0	50	0	0	0				2014-03-31 14:00	2014-04-07 16:00		2013-12-21 14:00	2013-12-29 16:00	2013-12-21 14:00	2013-12-29 16:00	2013-12-21 14:00	2013-12-29 16:00	2014-03-31 14:00	2014-04-07 16:00		PT_Normal					oLu5FdYp0EOhL1kOrEb/4Q	Z38BzSg4C0em/pBJ7XdzLQ			N	0	0			2013-08-12 21:28	2013-09-14 22:01	admin	admin	
+%R	106786	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1930	2ND.MASONARY SHOPDRAWING APPROVAL		680	500	50	0	0	0	50	0	0	0				2014-04-08 08:00	2014-04-15 10:00		2013-12-30 08:00	2014-01-06 10:00	2013-12-30 08:00	2014-01-06 10:00	2013-12-30 08:00	2014-01-06 10:00	2014-04-08 08:00	2014-04-15 10:00		PT_Normal					u3jpuKDa+EKi/AyltOzwaQ	kRFsos6MaUKvbXGIhyxPjg			N	0	0			2013-08-12 21:28	2013-09-14 22:01	admin	admin	
+%R	106787	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1940	3RD.MASONARY SHOPDRAWING SUBMITAL		890	0	50	0	0	0	50	0	0	0				2014-05-08 10:00	2014-05-15 12:00		2013-12-30 08:00	2014-01-06 10:00	2013-12-30 08:00	2014-01-06 10:00	2013-12-30 08:00	2014-01-06 10:00	2014-05-08 10:00	2014-05-15 12:00		PT_Normal					fvyxh3cL3k6BSI8ZBydTfQ	oLu5FdYp0EOhL1kOrEb/4Q			N	0	0			2013-08-12 21:29	2013-09-14 22:01	admin	admin	
+%R	106788	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1950	3RD.MASONARY SHOPDRAWING APPROVAL		890	620	50	0	0	0	50	0	0	0				2014-05-15 12:00	2014-05-22 14:00		2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	2014-05-15 12:00	2014-05-22 14:00		PT_Normal					LGMJ8Kufw0SAhqEudYeJZw	u3jpuKDa+EKi/AyltOzwaQ			N	0	0			2013-08-12 21:29	2013-09-14 22:01	admin	admin	
+%R	106789	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1960	ROOF MASONARY SHOPDRAWING SUBMITAL		1130	0	50	0	0	0	50	0	0	0				2014-06-19 12:00	2014-06-26 14:00		2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	2014-06-19 12:00	2014-06-26 14:00		PT_Normal					QcDU0rQLjku5wXIk39GFcw	fvyxh3cL3k6BSI8ZBydTfQ			N	0	0			2013-08-12 21:30	2013-09-14 22:01	admin	admin	
+%R	106790	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1970	ROOF MASONARY SHOPDRAWING APPROVAL		1130	670	50	0	0	0	50	0	0	0				2014-06-26 14:00	2014-07-03 16:00		2014-01-13 12:00	2014-01-20 14:00	2014-01-13 12:00	2014-01-20 14:00	2014-01-13 12:00	2014-01-20 14:00	2014-06-26 14:00	2014-07-03 16:00		PT_Normal					QkmGGSUFjEymX7rV9k5eBw	LGMJ8Kufw0SAhqEudYeJZw			N	0	0			2013-08-12 21:30	2013-09-14 22:01	admin	admin	
+%R	106791	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1980	backfill MATERIAL SUBMITAL		3120	20	50	0	0	0	50	0	0	0				2015-01-21 12:00	2015-01-28 14:00		2013-10-21 12:00	2013-10-28 14:00	2013-10-21 12:00	2013-10-28 14:00	2013-10-21 12:00	2013-10-28 14:00	2015-01-21 12:00	2015-01-28 14:00		PT_Normal					NStGZ3VD/0irh3JxTraudQ	vmLIyhIhLEG24CYaZfQ/VQ			N	0	0			2013-08-13 19:53	2013-09-14 22:01	NotPrmUser	admin	
+%R	106792	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	1990	backfill MATERIAL APPROVAL		3120	0	50	0	0	0	50	0	0	0				2015-01-28 14:00	2015-02-04 16:00		2013-10-28 14:00	2013-11-05 08:00	2013-10-28 14:00	2013-11-05 08:00	2013-10-28 14:00	2013-11-05 08:00	2015-01-28 14:00	2015-02-04 16:00		PT_Normal					hOpOnTGaxkmRbvxJmGmEuQ	TuacrGbDr0WRWtKa32jmaA			N	0	0			2013-08-13 19:53	2013-09-14 22:01	NotPrmUser	admin	
+%R	106793	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	2000	backfill MATERIAL PROCURMENT		3120	0	50	0	0	0	50	0	0	0				2015-02-04 16:00	2015-02-12 10:00		2013-11-05 08:00	2013-11-12 10:00	2013-11-05 08:00	2013-11-12 10:00	2013-11-05 08:00	2013-11-12 10:00	2015-02-04 16:00	2015-02-12 10:00		PT_Normal					RXkyofc2h0SblyWJkc9cQw	qw1HsYouLU6xaWn1rnFCcA			N	0	0			2013-08-13 19:53	2013-09-14 22:01	NotPrmUser	admin	
+%R	106794	4680	26186	6690	0	N	N	N	CP_Drtn	TT_Task	DT_FixedDrtn	TK_NotStart	2010	backfill MATERIAL PROCURMENT		3070	0	100	0	0	0	100	0	0	0				2015-02-05 08:00	2015-02-19 12:00		2013-11-12 10:00	2013-11-26 14:00	2013-11-12 10:00	2013-11-26 14:00	2013-11-12 10:00	2013-11-26 14:00	2015-02-05 08:00	2015-02-19 12:00		PT_Normal					phLFr/yRMEqDr9QsHt4bEA	NGECyq34c0yW5SZeRV9gQw			N	0	0			2013-08-13 19:53	2013-09-14 22:01	NotPrmUser	admin	
+%T	ACTVCODE
+%F	actv_code_id	parent_actv_code_id	actv_code_type_id	actv_code_name	short_name	seq_num	color
+%R	7489		1736	earthwork	06	5	0000FF
+%R	7490		1734	test project	project	0	0000FF
+%R	7491		1735	substructure	03	2	0000FF
+%R	7492		1735	supersturcture	04	3	0000FF
+%R	7493		1735	rough finishes	05	100	0000FF
+%R	7494		1735	final finishes	06	200	0000FF
+%R	7495		1735	mechincal works	07	300	0000FF
+%R	7496		1735	electrical work	08	400	0000FF
+%R	7497		1735	confeying system	09	500	0000FF
+%R	7498		1736	concrete work	07	6	0000FF
+%R	7499		1736	finshes	09	200	0000FF
+%R	7500		1736	mechincal	10	300	0000FF
+%R	7501		1736	electrical	11	400	0000FF
+%R	7502		1736	thermal	12	500	0000FF
+%R	7503		1736	elevator	13	600	0000FF
+%R	7504		1735	closeout	10	600	0000FF
+%R	7505		1737	underground	01	0	0000FF
+%R	7506		1737	basement floor	02	1	0000FF
+%R	7507		1737	ground floor	03	2	0000FF
+%R	7508		1737	1st floor	04	100	0000FF
+%R	7509		1737	2nd floor	05	200	0000FF
+%R	7510		1737	3rd floor	06	300	0000FF
+%R	7511		1737	roof floor	07	400	0000FF
+%R	7512		1737	enterance & staircase	08	500	0000FF
+%R	7513		1737	facades	09	600	0000FF
+%R	7514		1736	masonary	08	100	0000FF
+%R	7515		1737	all floor	10	700	0000FF
+%R	7516		1735	general milestone	01	0	0000FF
+%R	7517		1735	engineering work	02	1	0000FF
+%R	7518		1736	general	01	0	0000FF
+%R	7519		1736	civil shopdrawing	02	1	0000FF
+%R	7520		1736	arch shopdrwaing	03	2	0000FF
+%R	7521		1736	civil material	04	3	0000FF
+%R	7522		1736	finishing material	05	4	0000FF
+%T	PROJCOST
+%F	cost_item_id	acct_id	pobs_id	cost_type_id	proj_id	task_id	cost_name	po_number	vendor_name	act_cost	cost_per_qty	remain_cost	target_cost	cost_load_type	auto_compute_act_flag	target_qty	qty_name	cost_descr	contract_manager_import
+%R	19306				4680	106234	nail			0.00	10.00	100.00	100.00	CL_Start	N	10			
+%R	19307				4680	106234	lunch			0.00	150.00	150.00	150.00	CL_End	N	1			
+%R	19308			4	4680	106235	steel tie			0.00	5.00	500.00	500.00	CL_Start	N	100			
+%R	19309				4680	106235	lunch			0.00	150.00	150.00	150.00	CL_Start	N	1			
+%R	19310			4	4680	106236	steel ties			0.00	5.00	750.00	750.00	CL_Start	N	150			
+%R	19311				4680	106236	lunch			0.00	150.00	150.00	150.00	CL_Start	N	1			
+%R	19312			4	4680	106237	steel ties			0.00	5.00	500.00	500.00	CL_Start	N	100			
+%R	19313				4680	106237	lunch			0.00	150.00	150.00	150.00	CL_End	N	1			
+%R	19314			4	4680	106239	steel tirs			0.00	5.00	500.00	500.00	CL_Start	N	100			
+%R	19315				4680	106239	lunch			0.00	150.00	150.00	150.00	CL_End	N	1			
+%T	TASKPRED
+%F	task_pred_id	task_id	pred_task_id	proj_id	pred_proj_id	pred_type	lag_hr_cnt	float_path	aref	arls
+%R	42802	106592	106559	4680	4680	PR_FS	0		2013-08-03 08:00	2013-08-03 08:00
+%R	42803	106071	106592	4680	4680	PR_FS	0		2013-09-16 12:00	2013-09-16 12:00
+%R	42804	106222	106071	4680	4680	PR_FS	0		2013-09-30 16:00	2013-10-01 08:00
+%R	42805	106224	106222	4680	4680	PR_FS	0		2013-10-10 14:00	2013-10-10 14:00
+%R	42806	106225	106224	4680	4680	PR_FS	0		2013-10-21 12:00	2013-10-21 12:00
+%R	42807	106226	106225	4680	4680	PR_FS	0		2013-11-07 12:00	2013-11-07 12:00
+%R	42808	106230	106226	4680	4680	PR_FS	0		2013-11-18 10:00	2013-11-18 10:00
+%R	42809	106228	106230	4680	4680	PR_FS	0		2013-11-21 16:00	2013-11-23 08:00
+%R	42810	106229	106228	4680	4680	PR_FS	0		2013-11-25 12:00	2013-11-25 12:00
+%R	42811	106223	106229	4680	4680	PR_FS	0		2013-11-26 14:00	2013-11-26 14:00
+%R	42812	106227	106223	4680	4680	PR_FS	0		2013-12-04 16:00	2013-12-05 08:00
+%R	42813	106231	106227	4680	4680	PR_FS	0		2013-12-08 12:00	2013-12-08 12:00
+%R	42814	106232	106231	4680	4680	PR_FS	0		2013-12-18 10:00	2013-12-18 10:00
+%R	42815	106233	106232	4680	4680	PR_FS	0		2014-01-02 14:00	2014-01-02 14:00
+%R	42816	106234	106233	4680	4680	PR_FS	0		2014-01-13 12:00	2014-01-13 12:00
+%R	42817	106235	106234	4680	4680	PR_FS	0		2014-01-29 10:00	2014-02-11 12:00
+%R	42818	106236	106235	4680	4680	PR_FS	0		2014-02-08 16:00	2014-02-22 10:00
+%R	42819	106237	106236	4680	4680	PR_FS	0		2014-02-23 12:00	2014-03-22 08:00
+%R	42820	106238	106237	4680	4680	PR_FS	0		2014-03-05 10:00	2014-03-31 14:00
+%R	42821	106239	106238	4680	4680	PR_FS	0		2014-03-19 14:00	2014-04-28 12:00
+%R	42822	106240	106239	4680	4680	PR_FS	0		2014-03-30 12:00	2014-05-08 10:00
+%R	42823	106241	106240	4680	4680	PR_FS	0		2014-04-13 16:00	2014-06-19 12:00
+%R	42824	106242	106241	4680	4680	PR_FS	0		2014-04-21 10:00	2014-06-26 14:00
+%R	42825	106248	106243	4680	4680	PR_FS	0		2014-02-02 16:00	2014-02-10 10:00
+%R	42826	106254	106248	4680	4680	PR_FS	0		2014-02-16 10:00	2014-03-08 14:00
+%R	42828	106266	106260	4680	4680	PR_FS	0		2014-04-03 10:00	2014-05-22 14:00
+%R	42829	106272	106266	4680	4680	PR_FS	0		2014-04-28 12:00	2014-07-05 08:00
+%R	42831	106249	106244	4680	4680	PR_FS	0		2014-02-23 12:00	2014-04-12 14:00
+%R	42832	106255	106249	4680	4680	PR_FS	0		2014-03-15 16:00	2014-05-03 10:00
+%R	42833	106261	106255	4680	4680	PR_FS	0		2014-04-05 12:00	2014-05-22 14:00
+%R	42834	106267	106261	4680	4680	PR_FS	0		2014-04-24 16:00	2014-06-12 10:00
+%R	42835	106273	106267	4680	4680	PR_FS	0		2014-05-18 16:00	2014-07-07 12:00
+%R	42836	106244	106243	4680	4680	PR_FS	0		2014-02-02 16:00	2014-03-23 10:00
+%R	42837	106249	106248	4680	4680	PR_FS	0		2014-02-16 10:00	2014-04-12 14:00
+%R	42838	106255	106254	4680	4680	PR_FS	0		2014-03-11 10:00	2014-05-03 10:00
+%R	42840	106261	106260	4680	4680	PR_FS	0		2014-04-03 10:00	2014-05-22 14:00
+%R	42841	106267	106266	4680	4680	PR_FS	0		2014-04-28 12:00	2014-06-12 10:00
+%R	42842	106273	106272	4680	4680	PR_FS	0		2014-04-30 16:00	2014-07-07 12:00
+%R	42843	106330	106244	4680	4680	PR_FS	0		2014-02-23 12:00	2014-05-05 14:00
+%R	42844	106333	106249	4680	4680	PR_FS	0		2014-03-15 16:00	2014-05-20 10:00
+%R	42845	106336	106255	4680	4680	PR_FS	0		2014-04-05 12:00	2014-06-03 14:00
+%R	42846	106339	106261	4680	4680	PR_FS	0		2014-04-24 16:00	2014-06-18 10:00
+%R	42847	106342	106267	4680	4680	PR_FS	0		2014-05-18 16:00	2014-07-02 14:00
+%R	42848	106345	106273	4680	4680	PR_FS	0		2014-05-28 14:00	2014-07-17 10:00
+%R	42849	106333	106330	4680	4680	PR_FS	0		2014-03-09 16:00	2014-05-20 10:00
+%R	42850	106336	106333	4680	4680	PR_FS	0		2014-03-30 12:00	2014-06-03 14:00
+%R	42851	106339	106336	4680	4680	PR_FS	0		2014-04-19 16:00	2014-06-18 10:00
+%R	42852	106342	106339	4680	4680	PR_FS	0		2014-05-10 12:00	2014-07-02 14:00
+%R	42853	106345	106342	4680	4680	PR_FS	0		2014-06-02 12:00	2014-07-17 10:00
+%R	42854	106348	106345	4680	4680	PR_FS	0		2014-06-16 16:00	2014-07-31 14:00
+%R	42855	106351	106348	4680	4680	PR_FS	0		2014-07-01 12:00	2014-08-16 10:00
+%R	42856	106320	106318	4680	4680	PR_FS	0		2014-02-12 14:00	2014-02-23 12:00
+%R	42858	106324	106322	4680	4680	PR_FS	0		2014-03-20 16:00	2014-04-29 14:00
+%R	42859	106326	106324	4680	4680	PR_FS	0		2014-04-13 16:00	2014-06-07 10:00
+%R	42860	106328	106326	4680	4680	PR_FS	0		2014-05-08 10:00	2014-07-16 08:00
+%R	42861	106318	106243	4680	4680	PR_FS	0		2014-02-02 16:00	2014-02-03 08:00
+%R	42862	106320	106248	4680	4680	PR_FS	0		2014-02-16 10:00	2014-02-23 12:00
+%R	42863	106322	106254	4680	4680	PR_FS	0		2014-03-11 10:00	2014-03-24 12:00
+%R	42864	106324	106260	4680	4680	PR_FS	0		2014-04-03 10:00	2014-04-29 14:00
+%R	42865	106326	106266	4680	4680	PR_FS	0		2014-04-28 12:00	2014-06-07 10:00
+%R	42866	106328	106272	4680	4680	PR_FS	0		2014-04-30 16:00	2014-07-16 08:00
+%R	42869	106245	106318	4680	4680	PR_FS	0		2014-02-12 14:00	2014-02-12 14:00
+%R	42870	106250	106320	4680	4680	PR_FS	0		2014-02-25 16:00	2014-03-05 10:00
+%R	42871	106256	106322	4680	4680	PR_FS	0		2014-03-20 16:00	2014-04-03 10:00
+%R	42872	106262	106324	4680	4680	PR_FS	0		2014-04-13 16:00	2014-05-10 12:00
+%R	42873	106268	106326	4680	4680	PR_FS	0		2014-05-08 10:00	2014-06-17 08:00
+%R	42874	106274	106328	4680	4680	PR_FS	0		2014-05-12 16:00	2014-07-20 14:00
+%R	42875	106279	106274	4680	4680	PR_FS	0		2014-07-31 14:00	2014-07-31 14:00
+%R	42876	106281	106279	4680	4680	PR_FS	0		2014-08-25 16:00	2014-08-26 08:00
+%R	42877	106276	106274	4680	4680	PR_FS	0		2014-07-31 14:00	2015-01-01 08:00
+%R	42878	106277	106276	4680	4680	PR_FS	0		2014-08-06 14:00	2015-01-07 08:00
+%R	42879	106278	106277	4680	4680	PR_FS	0		2014-08-12 14:00	2015-01-13 08:00
+%R	42880	106280	106281	4680	4680	PR_SS	0		2014-08-26 08:00	2014-11-04 08:00
+%R	42881	106282	106281	4680	4680	PR_FS	0		2014-11-13 14:00	2015-02-12 10:00
+%R	42883	106312	106279	4680	4680	PR_FF	0		2014-07-26 14:00	2014-08-25 16:00
+%R	42884	106246	106318	4680	4680	PR_FS	0		2014-02-12 14:00	2014-12-07 14:00
+%R	42886	106258	106322	4680	4680	PR_FS	0		2014-03-20 16:00	2014-12-29 12:00
+%R	42887	106264	106324	4680	4680	PR_FS	0		2014-04-13 16:00	2015-01-13 08:00
+%R	42888	106270	106326	4680	4680	PR_FS	0		2014-05-08 10:00	2015-01-27 12:00
+%R	42889	106252	106246	4680	4680	PR_FS	0		2014-02-19 16:00	2014-12-15 08:00
+%R	42890	106258	106252	4680	4680	PR_FS	0		2014-03-06 12:00	2014-12-29 12:00
+%R	42891	106264	106258	4680	4680	PR_FS	0		2014-04-05 12:00	2015-01-13 08:00
+%R	42892	106270	106264	4680	4680	PR_FS	0		2014-04-28 12:00	2015-01-27 12:00
+%R	42893	106319	106246	4680	4680	PR_FS	0		2014-02-19 16:00	2015-01-26 10:00
+%R	42894	106321	106252	4680	4680	PR_FS	0		2014-03-06 12:00	2015-01-31 08:00
+%R	42895	106323	106258	4680	4680	PR_FS	0		2014-04-05 12:00	2015-02-03 14:00
+%R	42896	106325	106264	4680	4680	PR_FS	0		2014-04-28 12:00	2015-02-08 12:00
+%R	42897	106327	106270	4680	4680	PR_FS	0		2014-05-24 16:00	2015-02-12 10:00
+%R	42898	106321	106319	4680	4680	PR_FS	0		2014-02-24 14:00	2015-01-31 08:00
+%R	42899	106323	106321	4680	4680	PR_FS	0		2014-03-11 10:00	2015-02-03 14:00
+%R	42900	106325	106323	4680	4680	PR_FS	0		2014-04-09 10:00	2015-02-08 12:00
+%R	42901	106327	106325	4680	4680	PR_FS	0		2014-05-03 10:00	2015-02-12 10:00
+%R	42902	106329	106327	4680	4680	PR_FS	0		2014-05-28 14:00	2015-02-17 08:00
+%R	42903	106309	106278	4680	4680	PR_FS	0		2014-08-13 16:00	2015-01-14 10:00
+%R	42904	106250	106245	4680	4680	PR_FS	0		2014-03-05 10:00	2014-03-05 10:00
+%R	42905	106256	106250	4680	4680	PR_FS	0		2014-04-03 10:00	2014-04-03 10:00
+%R	42906	106262	106256	4680	4680	PR_FS	0		2014-05-10 12:00	2014-05-10 12:00
+%R	42907	106268	106262	4680	4680	PR_FS	0		2014-06-16 16:00	2014-06-17 08:00
+%R	42908	106274	106268	4680	4680	PR_FS	0		2014-07-20 14:00	2014-07-20 14:00
+%R	42909	106331	106245	4680	4680	PR_FS	0		2014-03-05 10:00	2014-06-01 10:00
+%R	42910	106334	106250	4680	4680	PR_FS	0		2014-04-03 10:00	2014-06-08 12:00
+%R	42911	106337	106256	4680	4680	PR_FS	0		2014-05-10 12:00	2014-06-26 14:00
+%R	42912	106340	106262	4680	4680	PR_FS	0		2014-06-16 16:00	2014-07-29 10:00
+%R	42913	106343	106268	4680	4680	PR_FS	0		2014-07-20 14:00	2014-08-20 08:00
+%R	42914	106346	106274	4680	4680	PR_FS	0		2014-07-31 14:00	2014-09-13 08:00
+%R	42915	106349	106279	4680	4680	PR_FS	0		2014-08-25 16:00	2014-11-06 12:00
+%R	42916	106352	106281	4680	4680	PR_FS	0		2014-11-13 14:00	2014-11-13 14:00
+%R	42917	106334	106331	4680	4680	PR_FS	0		2014-03-12 12:00	2014-06-08 12:00
+%R	42918	106337	106334	4680	4680	PR_FS	0		2014-04-10 12:00	2014-06-26 14:00
+%R	42919	106340	106337	4680	4680	PR_FS	0		2014-05-17 14:00	2014-07-29 10:00
+%R	42920	106343	106340	4680	4680	PR_FS	0		2014-06-24 10:00	2014-08-20 08:00
+%R	42921	106346	106343	4680	4680	PR_FS	0		2014-07-27 16:00	2014-09-13 08:00
+%R	42922	106349	106346	4680	4680	PR_FS	0		2014-08-07 16:00	2014-11-06 12:00
+%R	42923	106352	106349	4680	4680	PR_FS	0		2014-09-02 10:00	2014-11-13 14:00
+%R	42924	106251	106334	4680	4680	PR_FS	0		2014-04-10 12:00	2014-06-15 14:00
+%R	42925	106257	106337	4680	4680	PR_FS	0		2014-05-17 14:00	2014-07-05 08:00
+%R	42926	106263	106340	4680	4680	PR_FS	0		2014-06-24 10:00	2014-08-05 12:00
+%R	42927	106269	106343	4680	4680	PR_FS	0		2014-07-27 16:00	2014-08-27 10:00
+%R	42928	106275	106346	4680	4680	PR_FS	0		2014-08-07 16:00	2014-09-20 10:00
+%R	42929	106257	106251	4680	4680	PR_FS	0		2014-04-16 12:00	2014-07-05 08:00
+%R	42930	106263	106257	4680	4680	PR_FS	0		2014-05-22 14:00	2014-08-05 12:00
+%R	42931	106269	106263	4680	4680	PR_FS	0		2014-06-30 10:00	2014-08-27 10:00
+%R	42932	106275	106269	4680	4680	PR_FS	0		2014-08-02 16:00	2014-09-20 10:00
+%R	42933	106247	106251	4680	4680	PR_FS	0		2014-04-16 12:00	2014-06-21 14:00
+%R	42934	106253	106257	4680	4680	PR_FS	0		2014-05-22 14:00	2014-07-10 08:00
+%R	42935	106259	106263	4680	4680	PR_FS	0		2014-06-30 10:00	2014-08-11 12:00
+%R	42936	106265	106269	4680	4680	PR_FS	0		2014-08-02 16:00	2014-09-02 10:00
+%R	42937	106271	106275	4680	4680	PR_FS	0		2014-08-13 16:00	2014-09-25 10:00
+%R	42940	106253	106247	4680	4680	PR_FS	0		2014-05-04 12:00	2014-07-10 08:00
+%R	42941	106259	106253	4680	4680	PR_FS	0		2014-06-21 14:00	2014-08-11 12:00
+%R	42942	106265	106259	4680	4680	PR_FS	0		2014-07-21 16:00	2014-09-02 10:00
+%R	42943	106271	106265	4680	4680	PR_FS	0		2014-08-25 16:00	2014-09-25 10:00
+%R	42944	106283	106247	4680	4680	PR_FS	0		2014-05-04 12:00	2014-09-27 12:00
+%R	42945	106288	106247	4680	4680	PR_FS	0		2014-05-04 12:00	2014-07-08 14:00
+%R	42946	106294	106253	4680	4680	PR_FS	0		2014-06-21 14:00	2014-08-09 08:00
+%R	42947	106300	106259	4680	4680	PR_FS	0		2014-07-21 16:00	2014-09-08 10:00
+%R	42949	106294	106288	4680	4680	PR_FS	0		2014-06-03 14:00	2014-08-09 08:00
+%R	42950	106300	106294	4680	4680	PR_FS	0		2014-07-21 16:00	2014-09-08 10:00
+%R	42951	106306	106300	4680	4680	PR_FS	0		2014-08-21 10:00	2014-10-08 12:00
+%R	42952	106286	106285	4680	4680	PR_SS	0		2014-06-03 14:00	2014-07-29 10:00
+%R	42953	106287	106286	4680	4680	PR_SS	0		2014-06-03 14:00	2014-07-24 12:00
+%R	42954	106292	106291	4680	4680	PR_SS	0		2014-07-22 08:00	2014-08-18 14:00
+%R	42955	106293	106292	4680	4680	PR_SS	0		2014-07-22 08:00	2014-08-28 12:00
+%R	42956	106298	106297	4680	4680	PR_SS	0		2014-08-21 10:00	2014-09-18 08:00
+%R	42957	106299	106298	4680	4680	PR_SS	0		2014-08-21 10:00	2014-10-01 10:00
+%R	42958	106304	106303	4680	4680	PR_SS	0		2014-10-08 12:00	2014-10-19 10:00
+%R	42959	106305	106304	4680	4680	PR_SS	0		2014-10-08 12:00	2014-11-01 12:00
+%R	42960	106285	106288	4680	4680	PR_FS	0		2014-06-03 14:00	2014-08-09 08:00
+%R	42961	106291	106294	4680	4680	PR_FS	0		2014-07-21 16:00	2014-09-08 10:00
+%R	42962	106297	106300	4680	4680	PR_FS	0		2014-08-21 10:00	2014-10-08 12:00
+%R	42963	106303	106306	4680	4680	PR_FS	0		2014-10-08 12:00	2014-11-08 14:00
+%R	42965	106291	106285	4680	4680	PR_FS	0		2014-06-14 12:00	2014-09-08 10:00
+%R	42966	106297	106291	4680	4680	PR_FS	0		2014-08-11 12:00	2014-10-08 12:00
+%R	42967	106303	106297	4680	4680	PR_FS	0		2014-09-10 14:00	2014-11-08 14:00
+%R	42968	106292	106286	4680	4680	PR_FS	0		2014-06-18 10:00	2014-09-08 10:00
+%R	42969	106298	106292	4680	4680	PR_FS	0		2014-07-31 14:00	2014-10-08 12:00
+%R	42970	106304	106298	4680	4680	PR_FS	0		2014-08-28 12:00	2014-11-08 14:00
+%R	42971	106293	106287	4680	4680	PR_FS	0		2014-06-14 12:00	2014-09-08 10:00
+%R	42972	106299	106293	4680	4680	PR_FS	0		2014-07-31 14:00	2014-10-08 12:00
+%R	42973	106305	106299	4680	4680	PR_FS	0		2014-08-31 16:00	2014-11-08 14:00
+%R	42974	106316	106352	4680	4680	PR_FS	0		2014-11-20 16:00	2014-11-22 08:00
+%R	42975	106317	106316	4680	4680	PR_FS	0		2015-01-18 16:00	2015-01-19 08:00
+%R	42976	106313	106349	4680	4680	PR_FS	0		2014-09-02 10:00	2014-12-15 08:00
+%R	42977	106289	106287	4680	4680	PR_FS	0		2014-06-14 12:00	2014-08-18 14:00
+%R	42978	106295	106293	4680	4680	PR_FS	0		2014-07-31 14:00	2014-09-18 08:00
+%R	42979	106301	106299	4680	4680	PR_FS	0		2014-08-31 16:00	2014-10-19 10:00
+%R	42980	106307	106305	4680	4680	PR_FS	0		2014-10-19 10:00	2014-11-18 12:00
+%R	42981	106295	106289	4680	4680	PR_FS	0		2014-07-14 14:00	2014-09-18 08:00
+%R	42982	106301	106295	4680	4680	PR_FS	0		2014-08-31 16:00	2014-10-19 10:00
+%R	42983	106307	106301	4680	4680	PR_FS	0		2014-10-01 10:00	2014-11-18 12:00
+%R	42984	106311	106307	4680	4680	PR_FS	0		2014-11-18 12:00	2015-02-09 14:00
+%R	42985	106284	106283	4680	4680	PR_FS	0		2014-05-24 16:00	2014-10-18 08:00
+%R	42986	106290	106289	4680	4680	PR_FS	0		2014-07-14 14:00	2014-11-01 12:00
+%R	42987	106296	106295	4680	4680	PR_FS	0		2014-08-31 16:00	2014-11-17 10:00
+%R	42988	106302	106301	4680	4680	PR_FS	0		2014-10-01 10:00	2014-12-01 14:00
+%R	42989	106308	106307	4680	4680	PR_FS	0		2014-11-18 12:00	2014-12-18 14:00
+%R	42990	106290	106284	4680	4680	PR_FS	0		2014-06-08 12:00	2014-11-01 12:00
+%R	42991	106296	106290	4680	4680	PR_FS	0		2014-07-30 12:00	2014-11-17 10:00
+%R	42992	106302	106296	4680	4680	PR_FS	0		2014-09-15 12:00	2014-12-01 14:00
+%R	42993	106308	106302	4680	4680	PR_FS	0		2014-10-16 16:00	2014-12-18 14:00
+%R	42994	106332	106284	4680	4680	PR_FS	0		2014-06-08 12:00	2014-11-08 14:00
+%R	42995	106335	106290	4680	4680	PR_FS	0		2014-07-30 12:00	2014-11-18 12:00
+%R	42996	106338	106296	4680	4680	PR_FS	0		2014-09-15 12:00	2014-12-03 08:00
+%R	42997	106341	106302	4680	4680	PR_FS	0		2014-10-16 16:00	2014-12-17 12:00
+%R	42998	106344	106308	4680	4680	PR_FS	0		2014-12-01 14:00	2015-01-01 08:00
+%R	42999	106335	106332	4680	4680	PR_FS	0		2014-06-18 10:00	2014-11-18 12:00
+%R	43000	106338	106335	4680	4680	PR_FS	0		2014-08-13 16:00	2014-12-03 08:00
+%R	43001	106341	106338	4680	4680	PR_FS	0		2014-09-29 16:00	2014-12-17 12:00
+%R	43002	106344	106341	4680	4680	PR_FS	0		2014-11-01 12:00	2015-01-01 08:00
+%R	43003	106347	106344	4680	4680	PR_FS	0		2014-12-16 10:00	2015-01-15 12:00
+%R	43004	106350	106347	4680	4680	PR_FS	0		2014-12-25 16:00	2015-01-26 10:00
+%R	43005	106350	106317	4680	4680	PR_FS	0		2015-01-26 10:00	2015-01-26 10:00
+%R	43006	106314	106313	4680	4680	PR_FS	0		2014-09-21 12:00	2015-01-03 10:00
+%R	43007	106315	106314	4680	4680	PR_SS	0		2014-09-21 12:00	2014-12-22 10:00
+%R	43008	106347	106315	4680	4680	PR_FS	0		2014-10-04 14:00	2015-01-15 12:00
+%R	43009	106282	106280	4680	4680	PR_FS	0		2014-09-15 12:00	2015-02-12 10:00
+%R	43010	106310	106309	4680	4680	PR_FS	0		2014-08-27 10:00	2015-01-27 12:00
+%R	43011	106311	106310	4680	4680	PR_FS	0		2014-09-09 12:00	2015-02-09 14:00
+%R	43013	106355	106317	4680	4680	PR_FS	0		2015-01-26 10:00	2015-02-19 12:00
+%R	43014	106356	106329	4680	4680	PR_FS	0		2014-06-01 10:00	2015-02-19 12:00
+%R	43015	106353	106352	4680	4680	PR_FS	0		2014-11-20 16:00	2015-02-03 14:00
+%R	43016	106357	106353	4680	4680	PR_FS	0		2014-11-26 16:00	2015-02-09 14:00
+%R	43017	106354	106357	4680	4680	PR_FS	0		2015-02-09 14:00	2015-02-09 14:00
+%R	43018	106358	106354	4680	4680	PR_FS	0		2015-02-19 12:00	2015-02-19 12:00
+%R	43019	106356	106319	4680	4680	PR_FS	0		2014-02-24 14:00	2015-02-19 12:00
+%R	43020	106356	106321	4680	4680	PR_FS	0		2014-03-11 10:00	2015-02-19 12:00
+%R	43021	106356	106323	4680	4680	PR_FS	0		2014-04-09 10:00	2015-02-19 12:00
+%R	43022	106356	106325	4680	4680	PR_FS	0		2014-05-03 10:00	2015-02-19 12:00
+%R	43023	106356	106327	4680	4680	PR_FS	0		2014-05-28 14:00	2015-02-19 12:00
+%R	43024	106561	106560	4680	4680	PR_FS	0		2013-08-10 10:00	2013-10-14 10:00
+%R	43025	106225	106561	4680	4680	PR_FS	0		2013-08-17 12:00	2013-10-21 12:00
+%R	43026	106564	106560	4680	4680	PR_FS	0		2013-08-10 10:00	2013-10-02 10:00
+%R	43027	106565	106564	4680	4680	PR_FS	0		2013-08-17 12:00	2013-12-01 10:00
+%R	43028	106231	106565	4680	4680	PR_FS	0		2013-08-24 14:00	2013-12-08 12:00
+%R	43030	106767	106564	4680	4680	PR_FS	0		2013-08-17 12:00	2013-10-09 12:00
+%R	43031	106768	106767	4680	4680	PR_FS	0		2013-08-24 14:00	2013-12-11 08:00
+%R	43032	106232	106768	4680	4680	PR_FS	0		2013-08-31 16:00	2013-12-18 10:00
+%R	43035	106566	106767	4680	4680	PR_FS	0		2013-08-24 14:00	2013-10-16 14:00
+%R	43036	106567	106566	4680	4680	PR_FS	0		2013-08-31 16:00	2013-12-26 12:00
+%R	43037	106233	106567	4680	4680	PR_FS	0		2013-09-09 10:00	2014-01-02 14:00
+%R	43038	106769	106566	4680	4680	PR_FS	0		2013-08-31 16:00	2013-10-24 08:00
+%R	43039	106770	106769	4680	4680	PR_FS	0		2013-09-09 10:00	2014-01-06 10:00
+%R	43040	106234	106770	4680	4680	PR_FS	0		2013-09-16 12:00	2014-01-13 12:00
+%R	43041	106568	106769	4680	4680	PR_FS	0		2013-09-09 10:00	2013-10-31 10:00
+%R	43042	106569	106568	4680	4680	PR_FS	0		2013-09-16 12:00	2014-02-04 10:00
+%R	43043	106235	106569	4680	4680	PR_FS	0		2013-09-23 14:00	2014-02-11 12:00
+%R	43044	106771	106568	4680	4680	PR_FS	0		2013-09-16 12:00	2013-11-07 12:00
+%R	43045	106772	106771	4680	4680	PR_FS	0		2013-09-23 14:00	2014-02-15 08:00
+%R	43046	106236	106772	4680	4680	PR_FS	0		2013-09-30 16:00	2014-02-22 10:00
+%R	43047	106570	106771	4680	4680	PR_FS	0		2013-09-23 14:00	2013-11-14 14:00
+%R	43048	106571	106570	4680	4680	PR_FS	0		2013-09-30 16:00	2013-11-23 08:00
+%R	43049	106237	106571	4680	4680	PR_FS	0		2013-10-08 10:00	2014-03-22 08:00
+%R	43050	106773	106571	4680	4680	PR_FS	0		2013-10-08 10:00	2013-12-01 10:00
+%R	43051	106774	106773	4680	4680	PR_FS	0		2013-10-15 12:00	2014-03-24 12:00
+%R	43052	106238	106774	4680	4680	PR_FS	0		2013-10-22 14:00	2014-03-31 14:00
+%R	43053	106572	106773	4680	4680	PR_FS	0		2013-10-15 12:00	2013-12-08 12:00
+%R	43054	106573	106572	4680	4680	PR_FS	0		2013-10-22 14:00	2014-04-21 10:00
+%R	43055	106239	106573	4680	4680	PR_FS	0		2013-10-29 16:00	2014-04-28 12:00
+%R	43056	106775	106572	4680	4680	PR_FS	0		2013-10-22 14:00	2013-12-15 14:00
+%R	43057	106776	106775	4680	4680	PR_FS	0		2013-10-29 16:00	2014-05-01 08:00
+%R	43058	106240	106776	4680	4680	PR_FS	0		2013-11-06 10:00	2014-05-08 10:00
+%R	43059	106574	106775	4680	4680	PR_FS	0		2013-10-29 16:00	2013-12-23 08:00
+%R	43060	106575	106574	4680	4680	PR_FS	0		2013-11-06 10:00	2014-06-12 10:00
+%R	43061	106241	106575	4680	4680	PR_FS	0		2013-11-13 12:00	2014-06-19 12:00
+%R	43062	106777	106574	4680	4680	PR_FS	0		2013-11-06 10:00	2013-12-31 10:00
+%R	43063	106778	106777	4680	4680	PR_FS	0		2013-11-13 12:00	2014-01-07 12:00
+%R	43064	106242	106778	4680	4680	PR_FS	0		2013-11-20 14:00	2014-06-26 14:00
+%R	43065	106780	106779	4680	4680	PR_FS	0		2013-11-27 16:00	2014-01-22 08:00
+%R	43066	106782	106781	4680	4680	PR_FS	0		2013-12-07 10:00	2014-02-03 08:00
+%R	43067	106784	106783	4680	4680	PR_FS	0		2013-12-14 12:00	2014-03-24 12:00
+%R	43068	106786	106785	4680	4680	PR_FS	0		2013-12-29 16:00	2014-04-08 08:00
+%R	43069	106788	106787	4680	4680	PR_FS	0		2014-01-06 10:00	2014-05-15 12:00
+%R	43070	106790	106789	4680	4680	PR_FS	0		2014-01-13 12:00	2014-06-26 14:00
+%R	43071	106779	106778	4680	4680	PR_FS	0		2013-11-20 14:00	2014-01-14 14:00
+%R	43072	106243	106780	4680	4680	PR_FS	0		2013-12-07 10:00	2014-01-29 10:00
+%R	43073	106781	106779	4680	4680	PR_FS	0		2013-11-27 16:00	2014-01-26 14:00
+%R	43074	106248	106782	4680	4680	PR_FS	0		2013-12-14 12:00	2014-02-10 10:00
+%R	43075	106783	106781	4680	4680	PR_FS	0		2013-12-07 10:00	2014-03-17 10:00
+%R	43076	106260	106784	4680	4680	PR_FS	0		2013-12-21 14:00	2014-04-15 10:00
+%R	43077	106785	106784	4680	4680	PR_FS	0		2013-12-21 14:00	2014-03-31 14:00
+%R	43078	106260	106786	4680	4680	PR_FS	0		2014-01-06 10:00	2014-04-15 10:00
+%R	43079	106787	106785	4680	4680	PR_FS	0		2013-12-29 16:00	2014-05-08 10:00
+%R	43080	106266	106788	4680	4680	PR_FS	0		2014-01-13 12:00	2014-05-22 14:00
+%R	43081	106789	106787	4680	4680	PR_FS	0		2014-01-06 10:00	2014-06-19 12:00
+%R	43082	106272	106790	4680	4680	PR_FS	0		2014-01-20 14:00	2014-07-05 08:00
+%R	43083	106579	106228	4680	4680	PR_SF	0		2013-11-07 12:00	2015-02-17 08:00
+%R	43087	106578	106579	4680	4680	PR_SF	0		2013-10-31 10:00	2015-01-21 12:00
+%R	43088	106577	106578	4680	4680	PR_SF	0		2013-10-24 08:00	2015-01-21 12:00
+%R	43089	106576	106577	4680	4680	PR_SF	0		2013-10-16 14:00	2015-02-12 10:00
+%R	43090	106794	106223	4680	4680	PR_SF	0		2013-11-12 10:00	2015-02-12 10:00
+%R	43091	106793	106794	4680	4680	PR_SF	0		2013-11-05 08:00	2015-01-28 14:00
+%R	43092	106792	106793	4680	4680	PR_SF	0		2013-10-28 14:00	2015-01-28 14:00
+%R	43093	106791	106792	4680	4680	PR_SF	0		2013-10-21 12:00	2015-01-21 12:00
+%R	43095	106580	106791	4680	4680	PR_FS	0		2013-10-28 14:00	2015-01-28 14:00
+%R	43097	106583	106230	4680	4680	PR_SF	0		2013-10-05 14:00	2015-02-15 14:00
+%R	43098	106582	106583	4680	4680	PR_SF	0		2013-09-28 12:00	2015-01-07 08:00
+%R	43099	106581	106582	4680	4680	PR_SF	0		2013-09-21 10:00	2015-02-05 08:00
+%R	43100	106580	106581	4680	4680	PR_SF	0		2013-09-14 08:00	2015-01-28 14:00
+%R	43101	106580	106791	4680	4680	PR_FF	0		2013-10-21 12:00	2015-02-04 16:00
+%R	43102	106580	106577	4680	4680	PR_FS	0		2013-10-31 10:00	2015-01-28 14:00
+%R	43103	106587	106246	4680	4680	PR_SF	0		2013-11-14 14:00	2015-02-12 10:00
+%R	43104	106586	106587	4680	4680	PR_SF	0		2013-11-07 12:00	2014-11-24 12:00
+%R	43105	106585	106586	4680	4680	PR_SF	0		2013-10-31 10:00	2015-02-12 10:00
+%R	43106	106584	106585	4680	4680	PR_SF	0		2013-10-24 08:00	2015-02-05 08:00
+%R	43107	106584	106580	4680	4680	PR_FS	0		2013-11-07 12:00	2015-02-05 08:00
+%R	43108	106591	106282	4680	4680	PR_SF	0		2014-10-23 08:00	2015-02-12 10:00
+%R	43109	106590	106591	4680	4680	PR_SF	0		2014-10-15 14:00	2015-01-28 14:00
+%R	43110	106589	106590	4680	4680	PR_SF	0		2014-10-08 12:00	2015-02-12 10:00
+%R	43111	106588	106589	4680	4680	PR_SF	0		2014-10-01 10:00	2015-02-12 10:00
+%R	43112	106588	106584	4680	4680	PR_FS	0		2013-11-14 14:00	2015-02-12 10:00
+%R	43113	106357	106350	4680	4680	PR_FS	0		2015-02-09 14:00	2015-02-09 14:00
+%R	43114	106281	106351	4680	4680	PR_FS	0		2014-07-12 10:00	2014-08-26 08:00
+%R	43115	106306	106271	4680	4680	PR_FS	0		2014-09-08 10:00	2014-10-08 12:00
+%R	43116	106355	106311	4680	4680	PR_FS	0		2014-11-29 10:00	2015-02-19 12:00
+%R	43117	106281	106312	4680	4680	PR_FS	0		2014-08-25 16:00	2014-08-26 08:00
+%R	43718	106243	106234	4680	4680	PR_FS	0		2014-01-29 10:00	2014-01-29 10:00
+%R	44957	106248	106234	4680	4680	PR_FS	0		2014-01-29 10:00	2014-02-10 10:00
+%R	44958	106254	106236	4680	4680	PR_FS	0		2014-02-23 12:00	2014-03-08 14:00
+%R	44959	106260	106238	4680	4680	PR_FS	0		2014-03-19 14:00	2014-04-15 10:00
+%R	44960	106266	106240	4680	4680	PR_FS	0		2014-04-13 16:00	2014-05-22 14:00
+%R	44961	106272	106242	4680	4680	PR_FS	0		2014-04-28 12:00	2014-07-05 08:00
+%T	TASKPROC
+%F	proc_id	task_id	proj_id	seq_num	proc_name	complete_flag	proc_wt	complete_pct	proc_descr
+%R	32562	106233	4680	0	carpenter	N	1	0	<HTML><HEAD><META NAME=""GENERATOR"" Content=""Microsoft DHTML Editing Control""><TITLE></TITLE></HEAD><BODY><P>1-level of col</P><P>2- check shuter</P><P>3-leveling</P></BODY></HTML>
+%R	32563	106233	4680	0	steel fixer	N	1	0	<HTML><HEAD><META NAME=""GENERATOR"" Content=""Microsoft DHTML Editing Control""><TITLE></TITLE></HEAD><BODY><P>1-define height of steel bar</P><P>2-check col str and bars</P></BODY></HTML>
+%R	32564	106233	4680	0	concrete	N	1	0	<HTML><HEAD><META NAME=""GENERATOR"" Content=""Microsoft DHTML Editing Control""><TITLE></TITLE></HEAD><BODY><P>1- ordering for concrete</P></BODY></HTML>
+%R	32565	106236	4680	0	capenter work	N	1	0	<HTML><HEAD><META NAME=""GENERATOR"" Content=""Microsoft DHTML Editing Control""><TITLE></TITLE></HEAD><BODY><P>1- check dimension of slab</P><P>2- leveling of slab</P><P>&nbsp;</P></BODY></HTML>
+%R	32566	106236	4680	0	steel fixer	N	1	0	<HTML><HEAD><META NAME=""GENERATOR"" Content=""Microsoft DHTML Editing Control""><TITLE></TITLE></HEAD><BODY><P>1- check steel on the slab</P></BODY></HTML>
+%R	32567	106236	4680	0	concrete	N	1	0	<HTML><HEAD><META NAME=""GENERATOR"" Content=""Microsoft DHTML Editing Control""><TITLE></TITLE></HEAD><BODY><P>1-ordering concrete</P></BODY></HTML>
+%T	TASKRSRC
+%F	taskrsrc_id	task_id	proj_id	cost_qty_link_flag	role_id	acct_id	rsrc_id	pobs_id	skill_level	remain_qty	target_qty	remain_qty_per_hr	target_lag_drtn_hr_cnt	target_qty_per_hr	act_ot_qty	act_reg_qty	relag_drtn_hr_cnt	ot_factor	cost_per_qty	target_cost	act_reg_cost	act_ot_cost	remain_cost	act_start_date	act_end_date	restart_date	reend_date	target_start_date	target_end_date	rem_late_start_date	rem_late_end_date	rollup_dates_flag	target_crv	remain_crv	actual_crv	ts_pend_act_end_flag	guid	rate_type	act_this_per_cost	act_this_per_qty	curv_id	rsrc_type	cost_per_qty_source_type	create_user	create_date	has_rsrchours	taskrsrc_sum_id
+%R	89065	106071	4680	Y			10552			56	56	0.8	0	0.8	0	0	0		30.00	1680.00	0.00	0.00	1680.00			2013-09-16 12:00	2013-09-26 10:00	2013-09-16 12:00	2013-09-26 10:00	2013-09-21 10:00	2013-09-30 16:00	Y				N	yTYbfQeOK0S4fDQtBP3Cmw	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:09		
+%R	89066	106071	4680	Y			10552			72	72	1.02857143	0	1.02857143	0	0	0		30.00	2160.00	0.00	0.00	2160.00			2013-09-16 12:00	2013-09-26 10:00	2013-09-16 12:00	2013-09-26 10:00	2013-09-21 10:00	2013-09-30 16:00	Y				N	KuixuW1JlkuHWGet1l81Hw	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:09		
+%R	89067	106071	4680	Y			10553			64	64	0.8	20	0.8	0	0	20		20.00	1280.00	0.00	0.00	1280.00			2013-09-19 08:00	2013-09-30 16:00	2013-09-19 08:00	2013-09-30 16:00	2013-09-19 08:00	2013-09-30 16:00	Y				N	f3cljKVXh0OjsFUCii+8uw	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:11		
+%R	89068	106071	4680	Y			10554			56	56	0.8	30	0.8	0	0	30		15.00	840.00	0.00	0.00	840.00			2013-09-21 10:00	2013-09-30 16:00	2013-09-21 10:00	2013-09-30 16:00	2013-09-21 10:00	2013-09-30 16:00	Y				N	8di6AOaQB0uke6X/qumthA	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:11		
+%R	89069	106071	4680	Y			10554			56	56	0.8	30	0.8	0	0	30		15.00	840.00	0.00	0.00	840.00			2013-09-21 10:00	2013-09-30 16:00	2013-09-21 10:00	2013-09-30 16:00	2013-09-21 10:00	2013-09-30 16:00	Y				N	U8NZVgcDvUOTEjE4W9OyyQ	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:11		
+%R	89073	106222	4680	Y			10566			1500	1500	21.42857143	0	21.42857143	0	0	0		13.00	19500.00	0.00	0.00	19500.00			2013-10-01 08:00	2013-10-10 14:00	2013-10-01 08:00	2013-10-10 14:00	2013-10-01 08:00	2013-10-10 14:00	Y				N	K8rgEnf+ZEu4BlsNbzw35A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-26 21:28		
+%R	89074	106223	4680	Y			10553			32	32	0.8	0	0.8	0	0	0		20.00	640.00	0.00	0.00	640.00			2013-11-26 14:00	2013-12-03 14:00	2013-11-26 14:00	2013-12-03 14:00	2013-11-30 08:00	2013-12-04 16:00	Y				N	S8OPkwX6k0q/p1Ii6qWugQ	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:29		
+%R	89075	106223	4680	Y			10553			24	24	0.8	0	0.8	0	0	0		20.00	480.00	0.00	0.00	480.00			2013-11-26 14:00	2013-12-02 12:00	2013-11-26 14:00	2013-12-02 12:00	2013-12-01 10:00	2013-12-04 16:00	Y				N	+zqCsLw9rUON500g2vl/5A	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:31		
+%R	89076	106223	4680	Y			10555			40	40	2	30	2	0	0	30		5.00	200.00	0.00	0.00	200.00			2013-12-02 12:00	2013-12-04 16:00	2013-12-02 12:00	2013-12-04 16:00	2013-12-02 12:00	2013-12-04 16:00	Y				N	S15kCjpR2UOleNWjbCIF1g	COST_PER_QTY	0.00	0		RT_Equip	ST_Rsrc	admin	2013-08-26 21:31		
+%R	89077	106223	4680	Y			10567			500	500	12.5	10	12.5	0	0	10		2.00	1000.00	0.00	0.00	1000.00			2013-11-30 08:00	2013-12-04 16:00	2013-11-30 08:00	2013-12-04 16:00	2013-11-30 08:00	2013-12-04 16:00	Y				N	MqtGrzfv6Eisi0NdQh4HtQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-26 21:31		
+%R	89084	106224	4680	N			10557			208	208	3.46666667	0	3.46666667	0	0	0		0.00	8320.00	0.00	0.00	8320.00			2013-10-10 14:00	2013-10-20 10:00	2013-10-10 14:00	2013-10-20 10:00	2013-10-13 08:00	2013-10-21 12:00	Y				N	/EzyfHyBhkSAplHlPAs2Bg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-26 21:45		
+%R	89086	106224	4680	N			10560			208	208	20.8	60	20.8	0	0	60		0.00	45760.00	0.00	0.00	45760.00			2013-10-20 10:00	2013-10-21 12:00	2013-10-20 10:00	2013-10-21 12:00	2013-10-20 10:00	2013-10-21 12:00	Y				N	HFDcv9rs2Eipj9/CBNL/MQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-26 21:48		
+%R	89087	106225	4680	N			10557			200	200	4	0	4	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-10-21 12:00	2013-10-28 14:00	2013-10-21 12:00	2013-10-28 14:00	2013-10-31 10:00	2013-11-07 12:00	Y				N	ZimSLyENTEGzcFNuHE0fiQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-26 21:51		
+%R	89088	106225	4680	N			10558			304	304	10.13333333	50	10.13333333	0	0	50		0.00	0.00	0.00	0.00	0.00			2013-10-28 14:00	2013-11-02 12:00	2013-10-28 14:00	2013-11-02 12:00	2013-11-03 14:00	2013-11-07 12:00	Y				N	r3GqyESRokSdm1ph8a+yhQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-26 21:51		
+%R	89089	106225	4680	N			10560			304	304	30.4	110	30.4	0	0	110		0.00	82080.00	0.00	0.00	82080.00			2013-11-06 10:00	2013-11-07 12:00	2013-11-06 10:00	2013-11-07 12:00	2013-11-06 10:00	2013-11-07 12:00	Y				N	U5fn0gjFIkyvt5S+MxOKjw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-26 21:51		
+%R	89090	106225	4680	Y			10559			30	30	0.25	0	0.25	0	0	0	0	5000.00	150000.00	0.00	0.00	150000.00			2013-10-21 12:00	2013-11-07 12:00	2013-10-21 12:00	2013-11-07 12:00	2013-10-21 12:00	2013-11-07 12:00	Y				N	cZrdaFhCdkGOExIJNEOrgg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-26 21:51		
+%R	89091	106225	4680	N			10557			54	54	5.4	80	5.4	0	0	80		0.00	0.00	0.00	0.00	0.00			2013-11-02 12:00	2013-11-03 14:00	2013-11-02 12:00	2013-11-03 14:00	2013-11-06 10:00	2013-11-07 12:00	Y				N	WNo35Me63UmRJx5cczEQ8Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 20:20		
+%R	89092	106225	4680	N			10557			50	50	5	110	5	0	0	110		0.00	15200.00	0.00	0.00	15200.00			2013-11-06 10:00	2013-11-07 12:00	2013-11-06 10:00	2013-11-07 12:00	2013-11-06 10:00	2013-11-07 12:00	Y				N	bmAZvOuGs0y2PcatLzI3fw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 20:24		
+%R	89093	106225	4680	N			10558			96	96	4.8	90	4.8	0	0	90		0.00	15200.00	0.00	0.00	15200.00			2013-11-03 14:00	2013-11-06 10:00	2013-11-03 14:00	2013-11-06 10:00	2013-11-05 08:00	2013-11-07 12:00	Y				N	vfQdDpVOkkWKExDoy/f9fA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 20:26		
+%R	89094	106226	4680	N			10557			4920	4920	123	30	123	0	0	30		0.00	4920.00	0.00	0.00	4920.00			2013-11-12 10:00	2013-11-18 10:00	2013-11-12 10:00	2013-11-18 10:00	2013-11-12 10:00	2013-11-18 10:00	Y				N	9hhlCypPC0iCEnDsIgF7eA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 20:31		
+%R	89095	106226	4680	N			10558			4920	4920	164	0	164	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-11-07 12:00	2013-11-12 10:00	2013-11-07 12:00	2013-11-12 10:00	2013-11-13 12:00	2013-11-18 10:00	Y				N	SzKz2LpyHEeCPR3CaVbXmg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 20:31		
+%R	89097	106226	4680	Y			10559			3	3	0.3	0	0.3	0	0	0	0	5000.00	15000.00	0.00	0.00	15000.00			2013-11-07 12:00	2013-11-09 14:00	2013-11-07 12:00	2013-11-09 14:00	2013-11-17 08:00	2013-11-18 10:00	Y				N	lAtH00Ybb0ioKQXDHUn67w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 20:32		
+%R	89098	106226	4680	N			10560			82	82	8.2	60	8.2	0	0	60		0.00	22140.00	0.00	0.00	22140.00			2013-11-17 08:00	2013-11-18 10:00	2013-11-17 08:00	2013-11-18 10:00	2013-11-17 08:00	2013-11-18 10:00	Y				N	1UEIab20f0CuvEVqagmSHg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 20:34		
+%R	89099	106227	4680	Y			10559			1.5	1.5	0.15	0	0.15	0	0	0	0	5000.00	7500.00	0.00	0.00	7500.00			2013-12-05 08:00	2013-12-07 10:00	2013-12-05 08:00	2013-12-07 10:00	2013-12-07 10:00	2013-12-08 12:00	Y				N	jmiSpamxT0m6Ms7BiPIAZw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 20:36		
+%R	89100	106227	4680	N			10558			15	15	1.5	0	1.5	0	0	0		0.00	750.00	0.00	0.00	750.00			2013-12-05 08:00	2013-12-07 10:00	2013-12-05 08:00	2013-12-07 10:00	2013-12-07 10:00	2013-12-08 12:00	Y				N	LDfUp5w9wku0o8ewEkvvLA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 20:40		
+%R	89101	106227	4680	N			10560			15	15	1.5	10	1.5	0	0	10		0.00	4050.00	0.00	0.00	4050.00			2013-12-07 10:00	2013-12-08 12:00	2013-12-07 10:00	2013-12-08 12:00	2013-12-07 10:00	2013-12-08 12:00	Y				N	hJmq2GbsLk+C9xUtqQhwwA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 20:41		
+%R	89102	106230	4680	Y			10563			10	10	1	0	1	0	0	0	0	250.00	2500.00	0.00	0.00	2500.00			2013-11-18 10:00	2013-11-19 12:00	2013-11-18 10:00	2013-11-19 12:00	2013-11-20 14:00	2013-11-21 16:00	Y	10:10	10:10		N	JpDqhewhXEyZPJhM4qqVRw	COST_PER_QTY	0.00	0	9	RT_Mat	ST_Rsrc	admin	2013-08-28 20:53		
+%R	89103	106230	4680	N			10564			10	10	0.33333333	0	0.33333333	0	0	0		0.00	1200.00	0.00	0.00	1200.00			2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	Y				N	pZWlgMsgoEGSqX9Ej2TyIA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 20:54		
+%R	89104	106230	4680	Y			10568			4	4	0.4	0	0.4	0	0	0		500.00	2000.00	0.00	0.00	2000.00			2013-11-18 10:00	2013-11-19 12:00	2013-11-18 10:00	2013-11-19 12:00	2013-11-20 14:00	2013-11-21 16:00	Y				N	4UN8wZSdk0O2C7mk4DdNiw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 20:59		
+%R	89105	106230	4680	Y			10567			10	10	0.5	0	0.5	0	0	0		2.00	20.00	0.00	0.00	20.00			2013-11-18 10:00	2013-11-20 14:00	2013-11-18 10:00	2013-11-20 14:00	2013-11-19 12:00	2013-11-21 16:00	Y				N	+iHQLajY8kOGbGTfYi+k4w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 21:00		
+%R	89106	106229	4680	Y			10565			4000	4000	400	0	400	0	0	0		3.00	12000.00	0.00	0.00	12000.00			2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	Y				N	4441MZl/5UmVJYa83hGhIw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 21:04		
+%R	89107	106229	4680	Y			10562			250	250	25	0	25	0	0	0	0	0.00	0.00	0.00	0.00	0.00			2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	Y				N	kR+fLtA5sU2yPBfkwGExXA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 21:06		
+%R	89108	106228	4680	Y			10569			500	500	25	0	25	0	0	0		25.00	12500.00	0.00	0.00	12500.00			2013-11-23 08:00	2013-11-25 12:00	2013-11-23 08:00	2013-11-25 12:00	2013-11-23 08:00	2013-11-25 12:00	Y				N	p/eloDcgFUGby9vJ2PTMug	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 21:07		
+%R	89109	106231	4680	Y			10559			2.84	2.84	0.284	0	0.284	0	0	0	0	5000.00	14200.00	0.00	0.00	14200.00			2013-12-08 12:00	2013-12-09 14:00	2013-12-08 12:00	2013-12-09 14:00	2013-12-17 08:00	2013-12-18 10:00	Y				N	L4/CBW4OYUWdm0nvzGsXeQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 21:10		
+%R	89110	106231	4680	N			10558			11	11	0.55	0	0.55	0	0	0		0.00	1920.00	0.00	0.00	1920.00			2013-12-08 12:00	2013-12-10 16:00	2013-12-08 12:00	2013-12-10 16:00	2013-12-15 14:00	2013-12-18 10:00	Y				N	eG8nKVBY10W0wFdPolHH0w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 21:10		
+%R	89111	106231	4680	N			10557			32	32	0.64	20	0.64	0	0	20		0.00	1920.00	0.00	0.00	1920.00			2013-12-11 08:00	2013-12-18 10:00	2013-12-11 08:00	2013-12-18 10:00	2013-12-11 08:00	2013-12-18 10:00	Y				N	k43rUCzinE+JDI9q7FlEfw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 21:11		
+%R	89112	106231	4680	N			10560			32	32	3.2	60	3.2	0	0	60		0.00	8640.00	0.00	0.00	8640.00			2013-12-17 08:00	2013-12-18 10:00	2013-12-17 08:00	2013-12-18 10:00	2013-12-17 08:00	2013-12-18 10:00	Y				N	l25NpX9qDku3cNRmAeibXg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 21:12		
+%R	89113	106232	4680	Y			10559			16	16	1.6	0	1.6	0	0	0	0	5000.00	80000.00	0.00	0.00	80000.00			2013-12-18 10:00	2013-12-19 12:00	2013-12-18 10:00	2013-12-19 12:00	2014-01-01 12:00	2014-01-02 14:00	Y				N	hISsso1cb023/hvnOBHQEA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 21:20		
+%R	89114	106232	4680	N			10560			160	160	16	90	16	0	0	90		0.00	43200.00	0.00	0.00	43200.00			2014-01-01 12:00	2014-01-02 14:00	2014-01-01 12:00	2014-01-02 14:00	2014-01-01 12:00	2014-01-02 14:00	Y				N	aKOut6urE0OL6ri/d7aQkQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-28 21:20		
+%R	89115	106232	4680	N			10557			130	130	1.85714286	0	1.85714286	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-18 10:00	2013-12-29 16:00	2013-12-18 10:00	2013-12-29 16:00	2013-12-23 08:00	2014-01-02 14:00	Y				N	WTqTgruFZEOuhaTuFCCUDA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 21:20		
+%R	89116	106232	4680	N			10558			160	160	2	0	2	0	0	0		0.00	9600.00	0.00	0.00	9600.00			2013-12-18 10:00	2013-12-31 10:00	2013-12-18 10:00	2013-12-31 10:00	2013-12-21 14:00	2014-01-02 14:00	Y	142:76;8:4	142:76;8:4		N	Cc1yPxsxMUypj38aRcMQdA	COST_PER_QTY	0.00	0	9	RT_Labor	ST_Rsrc	admin	2013-08-28 21:20		
+%R	89117	106232	4680	N			10557			30	30	1.5	80	1.5	0	0	80		0.00	9600.00	0.00	0.00	9600.00			2013-12-31 10:00	2014-01-02 14:00	2013-12-31 10:00	2014-01-02 14:00	2013-12-31 10:00	2014-01-02 14:00	Y				N	iCBaiBOkYEumNkATu4GVLg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-28 21:28		
+%R	89118	106233	4680	N			10557			28	28	0.56	20	0.56	0	0	20		0.00	1400.00	0.00	0.00	1400.00			2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	Y				N	+TFVuuRUrUipKjBRD+Odxg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 19:41		
+%R	89119	106233	4680	N			10558			28	28	0.93333333	0	0.93333333	0	0	0		0.00	1400.00	0.00	0.00	1400.00			2014-01-02 14:00	2014-01-07 12:00	2014-01-02 14:00	2014-01-07 12:00	2014-01-08 14:00	2014-01-13 12:00	Y				N	qSp+VunwgEWCFiMOt6lEfQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 19:41		
+%R	89120	106233	4680	Y			10559			3	3	0.3	0	0.3	0	0	0	0	5000.00	15000.00	0.00	0.00	15000.00			2014-01-02 14:00	2014-01-04 16:00	2014-01-02 14:00	2014-01-04 16:00	2014-01-12 10:00	2014-01-13 12:00	Y				N	yfGgRkuUHEu0CLdtOg1GUQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 19:43		
+%R	89121	106233	4680	N			10560			70	70	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-02 14:00	2014-01-13 12:00	2014-01-02 14:00	2014-01-13 12:00	2014-01-02 14:00	2014-01-13 12:00	Y				N	hoL5Cg23A0CsjpXUnFmjZg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 19:44		
+%R	89122	106234	4680	Y			10559			100	100	10	0	10	0	0	0	0	5000.00	500000.00	0.00	0.00	500000.00			2014-01-13 12:00	2014-01-14 14:00	2014-01-13 12:00	2014-01-14 14:00	2014-01-28 08:00	2014-01-29 10:00	Y				N	C7XyyLhwT0aKOKAXrTu0DA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 19:49		
+%R	89124	106234	4680	N			10557			110	110	2.2	0	2.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-13 12:00	2014-01-20 14:00	2014-01-13 12:00	2014-01-20 14:00	2014-01-22 08:00	2014-01-29 10:00	Y				N	+Ca3s/bNwEG7MwDAYfm3Bw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 19:49		
+%R	89125	106234	4680	N			10558			148	148	2.46666667	50	2.46666667	0	0	50		0.00	7400.00	0.00	0.00	7400.00			2014-01-20 14:00	2014-01-29 10:00	2014-01-20 14:00	2014-01-29 10:00	2014-01-20 14:00	2014-01-29 10:00	Y				N	f2tE8lfeQEaqOYlYUaec5Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 19:49		
+%R	89126	106234	4680	N			10560			148	148	1.48	0	1.48	0	0	0		0.00	39960.00	0.00	0.00	39960.00			2014-01-13 12:00	2014-01-27 16:00	2014-01-13 12:00	2014-01-27 16:00	2014-01-14 14:00	2014-01-29 10:00	Y				N	b+qHMWv5H023TXfbPV0ZSg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 19:49		
+%R	89128	106234	4680	N			10557			38	38	1.9	80	1.9	0	0	80		0.00	7400.00	0.00	0.00	7400.00			2014-01-25 12:00	2014-01-27 16:00	2014-01-25 12:00	2014-01-27 16:00	2014-01-26 14:00	2014-01-29 10:00	Y				N	m45/aHJ3zUuCeqKajh5/8g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 19:50		
+%R	89129	106235	4680	Y			10559			3	3	0.3	60	0.3	0	0	60	0	5000.00	15000.00	0.00	0.00	15000.00			2014-02-06 14:00	2014-02-08 16:00	2014-02-06 14:00	2014-02-08 16:00	2014-02-20 08:00	2014-02-22 10:00	Y				N	6FiS2JtaY0+dr4sHh76cFg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 19:59		
+%R	89130	106235	4680	N			10557			24	24	0.48	20	0.48	0	0	20		0.00	1440.00	0.00	0.00	1440.00			2014-02-01 14:00	2014-02-08 16:00	2014-02-01 14:00	2014-02-08 16:00	2014-02-15 08:00	2014-02-22 10:00	Y				N	5+QmESMDxkelmgpleZW0Nw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 19:59		
+%R	89131	106235	4680	N			10558			24	24	0.6	0	0.6	0	0	0		0.00	1440.00	0.00	0.00	1440.00			2014-01-29 10:00	2014-02-04 10:00	2014-01-29 10:00	2014-02-04 10:00	2014-02-16 10:00	2014-02-22 10:00	Y				N	64ZZvW01mEOXqHwyjf4gAg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 19:59		
+%R	89132	106235	4680	N			10560			50	50	5	60	5	0	0	60		0.00	6480.00	0.00	0.00	6480.00			2014-02-06 14:00	2014-02-08 16:00	2014-02-06 14:00	2014-02-08 16:00	2014-02-20 08:00	2014-02-22 10:00	Y				N	0fi/wAUrS0O99ZsUw4MXmQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:00		
+%R	89133	106236	4680	Y			10559			100	100	10	0	10	0	0	0	0	5000.00	500000.00	0.00	0.00	500000.00			2014-02-09 08:00	2014-02-10 10:00	2014-02-09 08:00	2014-02-10 10:00	2014-03-06 12:00	2014-03-08 14:00	Y				N	uEcYbyGVYEOEDeLIDThiGw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:04		
+%R	89134	106236	4680	N			10558			155	155	3.875	50	3.875	0	0	50		0.00	9300.00	0.00	0.00	9300.00			2014-02-16 10:00	2014-02-22 10:00	2014-02-16 10:00	2014-02-22 10:00	2014-03-02 14:00	2014-03-08 14:00	Y				N	a6SP7znp2kKUHQqQqXhm1w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:04		
+%R	89135	106236	4680	N			10557			110	110	2.2	0	2.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-09 08:00	2014-02-16 10:00	2014-02-09 08:00	2014-02-16 10:00	2014-03-01 12:00	2014-03-08 14:00	Y				N	wbbyuG+qDUu+7TRWYS5eQg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:04		
+%R	89136	106236	4680	N			10560			155	155	15.5	90	15.5	0	0	90		0.00	0.00	0.00	0.00	0.00			2014-02-22 10:00	2014-02-23 12:00	2014-02-22 10:00	2014-02-23 12:00	2014-03-06 12:00	2014-03-08 14:00	Y				N	ehc99mnow0GhtlL3AZAR6A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:04		
+%R	89137	106236	4680	N			10557			45	45	2.25	80	2.25	0	0	80		0.00	9300.00	0.00	0.00	9300.00			2014-02-20 08:00	2014-02-23 12:00	2014-02-20 08:00	2014-02-23 12:00	2014-03-05 10:00	2014-03-08 14:00	Y				N	SSwiO7kLAUWbiXqe5olzEQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:06		
+%R	89138	106237	4680	Y			10559			2.5	2.5	0.03571429	0	0.03571429	0	0	0	0	5000.00	12500.00	0.00	0.00	12500.00			2014-02-23 12:00	2014-03-05 10:00	2014-02-23 12:00	2014-03-05 10:00	2014-03-22 08:00	2014-03-31 14:00	Y				N	B7Gq5yqBLU+WAXhCXv1mxA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:22		
+%R	89139	106237	4680	N			10557			22	22	0.44	20	0.44	0	0	20		0.00	1540.00	0.00	0.00	1540.00			2014-02-26 08:00	2014-03-05 10:00	2014-02-26 08:00	2014-03-05 10:00	2014-03-24 12:00	2014-03-31 14:00	Y				N	NlUDSvTrVEOVpHWoEXwlCg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:22		
+%R	89140	106237	4680	N			10558			22	22	0.55	0	0.55	0	0	0		0.00	1540.00	0.00	0.00	1540.00			2014-02-23 12:00	2014-03-01 12:00	2014-02-23 12:00	2014-03-01 12:00	2014-03-25 14:00	2014-03-31 14:00	Y				N	7T67OtCt3EuRC+GQmOtiyw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:22		
+%R	89141	106237	4680	N			10560			22	22	2.2	60	2.2	0	0	60		0.00	5940.00	0.00	0.00	5940.00			2014-03-04 08:00	2014-03-05 10:00	2014-03-04 08:00	2014-03-05 10:00	2014-03-30 12:00	2014-03-31 14:00	Y				N	ErMYQVslIkin6E3kcvcL+Q	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:22		
+%R	89142	106238	4680	N			10557			125	125	2.5	0	2.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-04-08 08:00	2014-04-15 10:00	Y				N	4oYpm0p9J0SSusyI2Zjqhw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:39		
+%R	89143	106238	4680	N			10558			176	176	3.52	30	3.52	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-03-10 08:00	2014-03-17 10:00	2014-03-10 08:00	2014-03-17 10:00	2014-04-08 08:00	2014-04-15 10:00	Y				N	kPfUGWcYd0+eNByHNMQCkg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:39		
+%R	89144	106238	4680	N			10560			176	176	17.6	90	17.6	0	0	90		0.00	47520.00	0.00	0.00	47520.00			2014-03-18 12:00	2014-03-19 14:00	2014-03-18 12:00	2014-03-19 14:00	2014-04-14 08:00	2014-04-15 10:00	Y				N	aGOquLSAYEyaBqg/qxbOYQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:39		
+%R	89145	106238	4680	Y			10559			20	20	2	0	2	0	0	0	0	5000.00	100000.00	0.00	0.00	100000.00			2014-03-05 10:00	2014-03-06 12:00	2014-03-05 10:00	2014-03-06 12:00	2014-04-14 08:00	2014-04-15 10:00	Y				N	Al5vbNQ41UGR3y6/mLjVbQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:40		
+%R	89146	106239	4680	Y			10559			2.5	2.5	0.25	0	0.25	0	0	0	0	5000.00	12500.00	0.00	0.00	12500.00			2014-03-19 14:00	2014-03-20 16:00	2014-03-19 14:00	2014-03-20 16:00	2014-05-07 08:00	2014-05-08 10:00	Y				N	YmjPorkrz0iXlTaDUKQYLg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:46		
+%R	89147	106239	4680	N			10557			20	20	0.5	30	0.5	0	0	30		0.00	1600.00	0.00	0.00	1600.00			2014-03-24 12:00	2014-03-30 12:00	2014-03-24 12:00	2014-03-30 12:00	2014-05-03 10:00	2014-05-08 10:00	Y				N	VlOEezk3nUiTe4cXccnN+w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:46		
+%R	89148	106239	4680	N			10558			20	20	0.5	0	0.5	0	0	0		0.00	1600.00	0.00	0.00	1600.00			2014-03-19 14:00	2014-03-25 14:00	2014-03-19 14:00	2014-03-25 14:00	2014-05-03 10:00	2014-05-08 10:00	Y				N	8g/YgrgT7kmSYjvi6ES0cw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:46		
+%R	89149	106239	4680	N			10560			20	20	2	60	2	0	0	60		0.00	5400.00	0.00	0.00	5400.00			2014-03-29 10:00	2014-03-30 12:00	2014-03-29 10:00	2014-03-30 12:00	2014-05-07 08:00	2014-05-08 10:00	Y				N	4KIS8ckUGUeyyyEluYk3Tg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:46		
+%R	89150	106240	4680	Y			10559			13	13	1.3	0	1.3	0	0	0	0	5000.00	65000.00	0.00	0.00	65000.00			2014-03-30 12:00	2014-03-31 14:00	2014-03-30 12:00	2014-03-31 14:00	2014-05-21 12:00	2014-05-22 14:00	Y				N	B4aTxnuP0USB0aUakbcfGQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:49		
+%R	89151	106240	4680	N			10560			40	40	4	90	4	0	0	90		0.00	35100.00	0.00	0.00	35100.00			2014-04-12 14:00	2014-04-13 16:00	2014-04-12 14:00	2014-04-13 16:00	2014-05-21 12:00	2014-05-22 14:00	Y				N	XeeU3PoIDEOcr41s6gm+lg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:50		
+%R	89152	106240	4680	N			10557			90	90	1.8	0	1.8	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-30 12:00	2014-04-06 14:00	2014-03-30 12:00	2014-04-06 14:00	2014-05-15 12:00	2014-05-22 14:00	Y				N	67iCupqyO0qNWzhWV9YdGw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:50		
+%R	89153	106240	4680	N			10558			130	130	2.16666667	20	2.16666667	0	0	20		0.00	10400.00	0.00	0.00	10400.00			2014-04-02 08:00	2014-04-10 12:00	2014-04-02 08:00	2014-04-10 12:00	2014-05-14 10:00	2014-05-22 14:00	Y				N	QLGkfX5is0aGx1Ab+X3QhA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:50		
+%R	89154	106241	4680	N			10558			15	15	0.5	10	0.5	0	0	10		0.00	1350.00	0.00	0.00	1350.00			2014-04-15 10:00	2014-04-19 16:00	2014-04-15 10:00	2014-04-19 16:00	2014-06-23 08:00	2014-06-26 14:00	Y				N	fmrA+onu20W027s5by9s7w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:54		
+%R	89155	106241	4680	N			10557			10	10	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-14 08:00	2014-04-16 12:00	2014-04-14 08:00	2014-04-16 12:00	2014-06-24 10:00	2014-06-26 14:00	Y				N	bSREAAzQj0WQB0QzEJb//Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:54		
+%R	89156	106241	4680	Y			10559			2	2	0.2	0	0.2	0	0	0	0	5000.00	10000.00	0.00	0.00	10000.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2014-06-25 12:00	2014-06-26 14:00	Y				N	7Up28FIUmESuUs+HzHvGNA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:55		
+%R	89157	106241	4680	N			10560			15	15	1.5	40	1.5	0	0	40		0.00	4050.00	0.00	0.00	4050.00			2014-04-20 08:00	2014-04-21 10:00	2014-04-20 08:00	2014-04-21 10:00	2014-06-25 12:00	2014-06-26 14:00	Y				N	Ceuv+Vk5k0q/Rig6exqMCQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:55		
+%R	89158	106242	4680	N			10558			15	15	0.5	10	0.5	0	0	10		0.00	1350.00	0.00	0.00	1350.00			2014-04-22 12:00	2014-04-27 10:00	2014-04-22 12:00	2014-04-27 10:00	2014-06-30 10:00	2014-07-03 16:00	Y				N	OeyWH4l3KkS6V4YlaKPGOA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:59		
+%R	89159	106242	4680	N			10557			10	10	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-21 10:00	2014-04-23 14:00	2014-04-21 10:00	2014-04-23 14:00	2014-07-01 12:00	2014-07-03 16:00	Y				N	96tE1Px3xEK818EU8kG5Gg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 20:59		
+%R	89160	106242	4680	Y			10559			2	2	0.2	40	0.2	0	0	40	0	5000.00	10000.00	0.00	0.00	10000.00			2014-04-27 10:00	2014-04-28 12:00	2014-04-27 10:00	2014-04-28 12:00	2014-07-02 14:00	2014-07-03 16:00	Y				N	swxJlF3+ikGcbLXGfmbU/A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:59		
+%R	89161	106242	4680	N			10560			15	15	1.5	40	1.5	0	0	40		0.00	4050.00	0.00	0.00	4050.00			2014-04-27 10:00	2014-04-28 12:00	2014-04-27 10:00	2014-04-28 12:00	2014-07-02 14:00	2014-07-03 16:00	Y				N	iGaBYhamg0eDRYJHUp0kdw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 20:59		
+%R	89163	106241	4680	N			10557			5	5	0.25	30	0.25	0	0	30		0.00	1350.00	0.00	0.00	1350.00			2014-04-17 14:00	2014-04-21 10:00	2014-04-17 14:00	2014-04-21 10:00	2014-06-24 10:00	2014-06-26 14:00	Y				N	K8mZ0m55Ck25l8qyQZLjtw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 21:01		
+%R	89164	106242	4680	N			10557			5	5	0.25	30	0.25	0	0	30		0.00	1350.00	0.00	0.00	1350.00			2014-04-26 08:00	2014-04-28 12:00	2014-04-26 08:00	2014-04-28 12:00	2014-07-01 12:00	2014-07-03 16:00	Y				N	Xe6LiCK9wk+8jo1omee+JA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 21:03		
+%R	89165	106278	4680	N			10560			50	50	5	0	5	0	0	0		0.00	11000.00	0.00	0.00	11000.00			2014-08-12 14:00	2014-08-13 16:00	2014-08-12 14:00	2014-08-13 16:00	2015-01-13 08:00	2015-01-14 10:00	Y				N	ZnSLJMIyN0S0kbgfa/FGfA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 21:19		
+%R	89166	106243	4680	Y			10563			8.8	8.8	0.88	0	0.88	0	0	0	0	250.00	2200.00	0.00	0.00	2200.00			2014-01-29 10:00	2014-01-30 12:00	2014-01-29 10:00	2014-01-30 12:00	2014-02-01 14:00	2014-02-02 16:00	Y				N	sq3qxEJhMUu5+UFL12lBvw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 21:31		
+%R	89167	106243	4680	Y			10568			2	2	0.2	0	0.2	0	0	0		500.00	1000.00	0.00	0.00	1000.00			2014-01-29 10:00	2014-01-30 12:00	2014-01-29 10:00	2014-01-30 12:00	2014-02-01 14:00	2014-02-02 16:00	Y				N	EGUOb0PF60+4IlqhHgRNHA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 21:33		
+%R	89168	106243	4680	Y			10567			6	6	0.6	0	0.6	0	0	0		2.00	12.00	0.00	0.00	12.00			2014-01-29 10:00	2014-01-30 12:00	2014-01-29 10:00	2014-01-30 12:00	2014-02-01 14:00	2014-02-02 16:00	Y				N	D3T/OJjpP0at1dUE5u+b2A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 21:33		
+%R	89169	106243	4680	Y			10570			6	6	0.6	0	0.6	0	0	0		12.00	72.00	0.00	0.00	72.00			2014-01-29 10:00	2014-01-30 12:00	2014-01-29 10:00	2014-01-30 12:00	2014-02-01 14:00	2014-02-02 16:00	Y				N	FofqBke7BUibtb+vlcqhLg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-30 21:38		
+%R	89170	106243	4680	N			10564			1280	1280	42.66666667	0	42.66666667	0	0	0		0.00	1056.00	0.00	0.00	1056.00			2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	Y				N	TSWETefcJU2zJlZXNnos9g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-30 21:38		
+%R	89171	106248	4680	Y			10563			50.6	50.6	5.06	0	5.06	0	0	0	0	250.00	12650.00	0.00	0.00	12650.00			2014-02-03 08:00	2014-02-04 10:00	2014-02-03 08:00	2014-02-04 10:00	2014-02-22 10:00	2014-02-23 12:00	Y				N	3i2hnXutOUW4ZoF6Mr5i9w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:29		
+%R	89173	106248	4680	Y			10570			37	37	3.7	0	3.7	0	0	0		12.00	444.00	0.00	0.00	444.00			2014-02-03 08:00	2014-02-04 10:00	2014-02-03 08:00	2014-02-04 10:00	2014-02-22 10:00	2014-02-23 12:00	Y				N	+jP6fgGKDUi7dUH/lvRzRg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:29		
+%R	89174	106248	4680	Y			10567			37	37	3.7	0	3.7	0	0	0		2.00	74.00	0.00	0.00	74.00			2014-02-03 08:00	2014-02-04 10:00	2014-02-03 08:00	2014-02-04 10:00	2014-02-22 10:00	2014-02-23 12:00	Y				N	RhUrMzVZbUCgk1XIgfBFSw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:29		
+%R	89175	106248	4680	N			10564			920	920	10.22222222	0	10.22222222	0	0	0		0.00	7360.00	0.00	0.00	7360.00			2014-02-03 08:00	2014-02-16 10:00	2014-02-03 08:00	2014-02-16 10:00	2014-02-10 10:00	2014-02-23 12:00	Y				N	D3MTSuaKIkuZXSwwupnlVA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 19:29		
+%R	89176	106254	4680	N			10564			0	1012	0	0	9.2	0	8000	0		0.00	8096.00	0.00	0.00	8096.00	2014-02-23 12:00		2014-02-23 12:00	2014-03-11 10:00	2014-02-23 12:00	2014-03-11 10:00	2014-03-08 14:00	2014-03-24 12:00	Y				N	HdFXHQiiR0WSpolOua1cMw	COST_PER_QTY	0.00	8000		RT_Labor	ST_Rsrc	admin	2013-08-31 19:33		
+%R	89177	106254	4680	Y			10563			2	65	0.2	0	6.5	0	64	0	0	250.00	16250.00	0.00	0.00	16500.00	2014-02-23 12:00		2014-02-23 12:00	2014-02-24 14:00	2014-02-23 12:00	2014-02-24 14:00	2014-03-23 10:00	2014-03-24 12:00	Y				N	op4OmqChgk2Fpxo+OqZTyA	COST_PER_QTY	0.00	64		RT_Mat	ST_Rsrc	admin	2013-08-31 19:33		
+%R	89178	106254	4680	Y			10567			0	41	0	0	4.1	0	41	0		2.00	82.00	0.00	0.00	82.00	2014-02-23 12:00		2014-02-23 12:00	2014-02-24 14:00	2014-02-23 12:00	2014-02-24 14:00	2014-03-23 10:00	2014-03-24 12:00	Y				N	xSVQ2IJji0m/rfXBAb1+Mw	COST_PER_QTY	0.00	41		RT_Mat	ST_Rsrc	admin	2013-08-31 19:33		
+%R	89179	106254	4680	Y			10570			2	41	0.2	0	4.1	0	39	0		12.00	492.00	0.00	0.00	492.00	2014-02-23 12:00		2014-02-23 12:00	2014-02-24 14:00	2014-02-23 12:00	2014-02-24 14:00	2014-03-23 10:00	2014-03-24 12:00	Y				N	wviF02QpnU6nOM4OR4Mvpg	COST_PER_QTY	0.00	39		RT_Mat	ST_Rsrc	admin	2013-08-31 19:33		
+%R	89180	106260	4680	Y			10563			58	58	0.58	0	0.58	0	0	0	0	250.00	14500.00	0.00	0.00	14500.00			2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00	Y				N	3TE/X6Mrqk23V0y0KA6QIg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:35		
+%R	89181	106260	4680	N			10564			1040	1040	10.4	0	10.4	0	0	0		0.00	8320.00	0.00	0.00	8320.00			2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00	Y				N	0uLR36tUB0KLZWJ1DDYGPA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 19:35		
+%R	89182	106260	4680	Y			10570			42	42	0.42	0	0.42	0	0	0		12.00	504.00	0.00	0.00	504.00			2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00	Y				N	ZfyaiPd73ECWEhlBjikbmQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:35		
+%R	89183	106260	4680	Y			10568			13.5	13.5	0.135	0	0.135	0	0	0		500.00	6750.00	0.00	0.00	6750.00			2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00	Y				N	1JYlDHA4u0iCvsNhnlj1aQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:35		
+%R	89184	106254	4680	Y			10568			13	13	1.3	0	1.3	0	0	0		500.00	6500.00	0.00	0.00	6500.00	2014-02-23 12:00		2014-02-23 12:00	2014-02-24 14:00	2014-02-23 12:00	2014-02-24 14:00	2014-03-23 10:00	2014-03-24 12:00	Y				N	+Ej9h+EIQEuFw351TIRymg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:36		
+%R	89185	106248	4680	Y			10568			12	12	1.2	0	1.2	0	0	0		500.00	6000.00	0.00	0.00	6000.00			2014-02-03 08:00	2014-02-04 10:00	2014-02-03 08:00	2014-02-04 10:00	2014-02-22 10:00	2014-02-23 12:00	Y				N	toeQyU3dmEixyiivbc8+aQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:36		
+%R	89186	106260	4680	Y			10567			42	42	0.42	0	0.42	0	0	0		2.00	84.00	0.00	0.00	84.00			2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00	Y				N	eEddK0nEn0SollQq3sUugw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:37		
+%R	89187	106266	4680	Y			10563			65	65	6.5	0	6.5	0	0	0	0	250.00	16250.00	0.00	0.00	16250.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2014-06-05 08:00	2014-06-07 10:00	Y				N	EmqEvB5CzU2gBBReuEyxVw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:39		
+%R	89188	106266	4680	Y			10567			48	48	4.8	0	4.8	0	0	0		2.00	96.00	0.00	0.00	96.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2014-06-05 08:00	2014-06-07 10:00	Y				N	uv4hTuzuGUmysJ7jJV7t2A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:39		
+%R	89189	106266	4680	Y			10570			48	48	4.8	0	4.8	0	0	0		12.00	576.00	0.00	0.00	576.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2014-06-05 08:00	2014-06-07 10:00	Y				N	fbuNIGWzo0Gc3WIRQDY6BQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:39		
+%R	89190	106266	4680	Y			10568			15.5	15.5	1.55	0	1.55	0	0	0		500.00	7750.00	0.00	0.00	7750.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2014-06-05 08:00	2014-06-07 10:00	Y				N	uymLyyvLG0CCSL4VYNSndg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:39		
+%R	89191	106266	4680	N			10564			1180	1180	11.8	0	11.8	0	0	0		0.00	9940.00	0.00	0.00	9940.00			2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2014-05-22 14:00	2014-06-07 10:00	Y				N	1s7I248ltE20tPu5C3c+ZQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 19:39		
+%R	89192	106272	4680	N			10564			160	160	16	0	16	0	0	0		0.00	1280.00	0.00	0.00	1280.00			2014-04-28 12:00	2014-04-29 14:00	2014-04-28 12:00	2014-04-29 14:00	2014-07-06 10:00	2014-07-07 12:00	Y				N	/F3XcrX1yk+sbsqIrMjXAw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 19:44		
+%R	89193	106272	4680	Y			10567			7	7	0.7	0	0.7	0	0	0		2.00	14.00	0.00	0.00	14.00			2014-04-28 12:00	2014-04-29 14:00	2014-04-28 12:00	2014-04-29 14:00	2014-07-06 10:00	2014-07-07 12:00	Y				N	Gw15cFO1CE6UcfyZ3KInUg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:44		
+%R	89194	106272	4680	Y			10563			8.8	8.8	0.88	0	0.88	0	0	0	0	250.00	2200.00	0.00	0.00	2200.00			2014-04-28 12:00	2014-04-29 14:00	2014-04-28 12:00	2014-04-29 14:00	2014-07-06 10:00	2014-07-07 12:00	Y				N	ldlB+ba+pUad7YZVFifMKw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:44		
+%R	89195	106272	4680	Y			10568			2.08	2.08	0.104	0	0.104	0	0	0		500.00	1040.00	0.00	0.00	1040.00			2014-04-28 12:00	2014-04-30 16:00	2014-04-28 12:00	2014-04-30 16:00	2014-07-05 08:00	2014-07-07 12:00	Y				N	yFJKsJU+ZEajp/mLr89OsQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:44		
+%R	89196	106272	4680	Y			10570			7	7	0.7	0	0.7	0	0	0		12.00	84.00	0.00	0.00	84.00			2014-04-28 12:00	2014-04-29 14:00	2014-04-28 12:00	2014-04-29 14:00	2014-07-06 10:00	2014-07-07 12:00	Y				N	ZWDhlho4Lk2/WCFJ2dEeNA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 19:44		
+%R	89197	106244	4680	Y			10571			26	26	0.18571429	0	0.18571429	0	0	0		200.00	5200.00	0.00	0.00	5200.00			2014-02-03 08:00	2014-02-23 12:00	2014-02-03 08:00	2014-02-23 12:00	2014-03-23 10:00	2014-04-12 14:00	Y				N	na6b4FCJekeBLOiaTwpsSw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:13		
+%R	89198	106245	4680	N			10572			980	980	7	0	7	0	0	0		0.00	9080.00	0.00	0.00	9080.00			2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	Y				N	tsaXG/sA7EWT52TDcVGtfg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 20:31		
+%R	89199	106245	4680	N			10573			10	10	0.2	0	0.2	0	0	0		0.00	100.00	0.00	0.00	100.00			2014-02-12 14:00	2014-02-19 16:00	2014-02-12 14:00	2014-02-19 16:00	2014-02-26 08:00	2014-03-05 10:00	Y				N	tIc6M7Lr/UCSGD32o7TkUQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 20:31		
+%R	89200	106245	4680	Y			10568			2.94	2.94	0.294	0	0.294	0	0	0		500.00	1470.00	0.00	0.00	1470.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-03-04 08:00	2014-03-05 10:00	Y				N	QABFdrUEKkmxXJQslLwShg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:31		
+%R	89201	106245	4680	Y			10570			10	10	1	0	1	0	0	0		12.00	120.00	0.00	0.00	120.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-03-04 08:00	2014-03-05 10:00	Y				N	HijQ71sq80KMTeGG+tmczw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:31		
+%R	89202	106245	4680	N			10573			3	3	0.15	0	0.15	0	0	0		0.00	150.00	0.00	0.00	150.00			2014-02-12 14:00	2014-02-16 10:00	2014-02-12 14:00	2014-02-16 10:00	2014-03-02 14:00	2014-03-05 10:00	Y				N	dYRd5rt8FkuouDH57uAYkQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 20:31		
+%R	89203	106245	4680	Y			10567			20	20	2	0	2	0	0	0		2.00	40.00	0.00	0.00	40.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-03-04 08:00	2014-03-05 10:00	Y				N	H5Rici1QbkWWBxWKvDgcYw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:34		
+%R	89204	106245	4680	Y			10568			3	3	0.3	0	0.3	0	0	0		500.00	1500.00	0.00	0.00	1500.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-03-04 08:00	2014-03-05 10:00	Y				N	6Q7BWDyAR0WxOPIsIpLrRA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:34		
+%R	89205	106246	4680	Y			10576			0.1	0.1	0.01	0	0.01	0	0	0		750.00	75.00	0.00	0.00	75.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-12-13 14:00	2014-12-14 16:00	Y				N	cW4i2asfJ0ejCqjn4u5n+A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:44		
+%R	89206	106246	4680	N			10575			90	90	9	0	9	0	0	0		0.00	4500.00	0.00	0.00	4500.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-12-13 14:00	2014-12-14 16:00	Y				N	TItvkWz7lECeAM0Q9j+s6A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:44		
+%R	89207	106246	4680	Y			10568			1	1	0.1	0	0.1	0	0	0		500.00	500.00	0.00	0.00	500.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-12-13 14:00	2014-12-14 16:00	Y				N	mf+tIEWljE28DfJ0uLp8gQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:44		
+%R	89208	106246	4680	Y			10570			3	3	0.3	0	0.3	0	0	0		12.00	36.00	0.00	0.00	36.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-12-13 14:00	2014-12-14 16:00	Y				N	gVvmLa+dB0uwZ0iK9rYm3A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:45		
+%R	89209	106246	4680	Y			10567			2	2	0.2	0	0.2	0	0	0		2.00	4.00	0.00	0.00	4.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-12-13 14:00	2014-12-14 16:00	Y				N	QyNm9YBJsEGEDY7A6yc0jQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 20:45		
+%R	89210	106246	4680	N			10573			3	3	0.3	0	0.3	0	0	0		0.00	15.00	0.00	0.00	15.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-12-13 14:00	2014-12-14 16:00	Y				N	Ksdep/OuY0697nAs5NMb3g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 20:45		
+%R	89211	106246	4680	N			10573			50	50	5	0	5	0	0	0		0.00	50.00	0.00	0.00	50.00			2014-02-12 14:00	2014-02-13 16:00	2014-02-12 14:00	2014-02-13 16:00	2014-12-13 14:00	2014-12-14 16:00	Y				N	5GoftPOpl0WPwhj+jNve6Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 20:45		
+%R	89212	106246	4680	N			10574			90	90	1.8	0	1.8	0	0	0		0.00	1350.00	0.00	0.00	1350.00			2014-02-12 14:00	2014-02-19 16:00	2014-02-12 14:00	2014-02-19 16:00	2014-12-07 14:00	2014-12-14 16:00	Y				N	Iny5XqxxBUSriJZIjkus1g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 20:45		
+%R	89213	106247	4680	Y			10578			120	120	4	0	4	0	0	0		50.00	6000.00	0.00	0.00	6000.00			2014-04-16 12:00	2014-04-21 10:00	2014-04-16 12:00	2014-04-21 10:00	2014-07-05 08:00	2014-07-08 14:00	Y				N	jia5oIBScUeb6CvigiW34w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-08-31 21:04		
+%R	89214	106247	4680	Y			10577			600	600	5	0	5	0	0	0		12.00	7200.00	0.00	0.00	7200.00			2014-04-16 12:00	2014-05-04 12:00	2014-04-16 12:00	2014-05-04 12:00	2014-06-21 14:00	2014-07-08 14:00	Y				N	btHHrREnZUqzeXD2MxZGAg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-08-31 21:04		
+%R	89215	106249	4680	Y			10571			14	14	0.1	0	0.1	0	0	0		200.00	2800.00	0.00	0.00	2800.00			2014-02-23 12:00	2014-03-15 16:00	2014-02-23 12:00	2014-03-15 16:00	2014-04-12 14:00	2014-05-03 10:00	Y				N	BSVAZoMcG0qbVFknyUko+g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:07		
+%R	89216	106250	4680	N			10572			1698	1698	8.49	0	8.49	0	0	0		0.00	14156.00	0.00	0.00	14156.00			2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	Y				N	cWzj9/ATAk2Jmz5r/gRlOQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 19:08		
+%R	89217	106250	4680	Y			10570			20	20	2	0	2	0	0	0		12.00	240.00	0.00	0.00	240.00			2014-03-05 10:00	2014-03-06 12:00	2014-03-05 10:00	2014-03-06 12:00	2014-04-02 08:00	2014-04-03 10:00	Y				N	Kn3UP8x3S0O7HvpTqzyEOg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:08		
+%R	89219	106250	4680	Y			10568			5.5	5.5	0.55	0	0.55	0	0	0		500.00	2750.00	0.00	0.00	2750.00			2014-03-05 10:00	2014-03-06 12:00	2014-03-05 10:00	2014-03-06 12:00	2014-04-02 08:00	2014-04-03 10:00	Y				N	hzRVPgf6ekOjs0ms7Wx6Hw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:08		
+%R	89220	106250	4680	Y			10567			34	34	0.17	0	0.17	0	0	0		2.00	68.00	0.00	0.00	68.00			2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	Y				N	kslz9uhfREWvo11X451hHA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:15		
+%R	89221	106251	4680	Y			10579			34	34	0.85	0	0.85	0	0	0		120.00	4080.00	0.00	0.00	4080.00			2014-04-10 12:00	2014-04-16 12:00	2014-04-10 12:00	2014-04-16 12:00	2014-06-15 14:00	2014-06-21 14:00	Y				N	qzKXlOVaKEup4mSXap3mqQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 19:18		
+%R	89222	106252	4680	N			10574			270	270	2.7	0	2.7	0	0	0		0.00	4320.00	0.00	0.00	4320.00			2014-02-20 08:00	2014-03-06 12:00	2014-02-20 08:00	2014-03-06 12:00	2014-12-15 08:00	2014-12-29 12:00	Y				N	fpsmiAXgVUG3FLIAbaJ78A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 19:23		
+%R	89223	106252	4680	Y			10567			11	11	0.11	0	0.11	0	0	0		2.00	22.00	0.00	0.00	22.00			2014-02-20 08:00	2014-03-06 12:00	2014-02-20 08:00	2014-03-06 12:00	2014-12-15 08:00	2014-12-29 12:00	Y				N	nvTxNCzTx0KU3n73dtdOKw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:24		
+%R	89224	106252	4680	Y			10568			2.8	2.8	0.28	0	0.28	0	0	0		500.00	1400.00	0.00	0.00	1400.00			2014-02-20 08:00	2014-02-22 10:00	2014-02-20 08:00	2014-02-22 10:00	2014-12-28 10:00	2014-12-29 12:00	Y				N	8bQAAhtJpU2hFjilu0G7iQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:24		
+%R	89226	106252	4680	Y			10576			0.5	0.5	0.005	0	0.005	0	0	0		750.00	375.00	0.00	0.00	375.00			2014-02-20 08:00	2014-03-06 12:00	2014-02-20 08:00	2014-03-06 12:00	2014-12-15 08:00	2014-12-29 12:00	Y				N	WP6TwPs6GkCAxilefsAqvA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:24		
+%R	89227	106252	4680	Y			10570			10	10	1	0	1	0	0	0		12.00	120.00	0.00	0.00	120.00			2014-02-20 08:00	2014-02-22 10:00	2014-02-20 08:00	2014-02-22 10:00	2014-12-28 10:00	2014-12-29 12:00	Y				N	/N2gaOkjvUmRTxfY0P5hIQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:24		
+%R	89228	106252	4680	N			10575			270	270	27	0	27	0	0	0		0.00	21600.00	0.00	0.00	21600.00			2014-02-20 08:00	2014-02-22 10:00	2014-02-20 08:00	2014-02-22 10:00	2014-12-28 10:00	2014-12-29 12:00	Y				N	fqxdsjwe/EiaiK+iN0RrAQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:25		
+%R	89229	106253	4680	Y			10578			199	199	0.995	0	0.995	0	0	0		50.00	9950.00	0.00	0.00	9950.00			2014-05-22 14:00	2014-06-21 14:00	2014-05-22 14:00	2014-06-21 14:00	2014-07-10 08:00	2014-08-07 16:00	Y				N	GrJ6PZWOWU6wS7yTdxHh6A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 19:55		
+%R	89230	106253	4680	Y			10577			994	994	4.97	0	4.97	0	0	0		12.00	11928.00	0.00	0.00	11928.00			2014-05-22 14:00	2014-06-21 14:00	2014-05-22 14:00	2014-06-21 14:00	2014-07-10 08:00	2014-08-07 16:00	Y				N	f9vSBCtaS06K4lxNrNUlgA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 19:55		
+%R	89232	106255	4680	Y			10571			14	14	0.1	0	0.1	0	0	0		200.00	2800.00	0.00	0.00	2800.00			2014-03-16 08:00	2014-04-05 12:00	2014-03-16 08:00	2014-04-05 12:00	2014-05-03 10:00	2014-05-22 14:00	Y				N	fS6WK8G17kCaaIJ1Rb3fQQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:00		
+%R	89233	106256	4680	N			10572			2664	2664	10.656	0	10.656	0	0	0		0.00	24408.00	0.00	0.00	24408.00			2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	Y				N	EmQo9bY880WExxvzFuBkzg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 20:07		
+%R	89234	106256	4680	Y			10570			27	27	2.7	0	2.7	0	0	0		12.00	324.00	0.00	0.00	324.00			2014-04-03 10:00	2014-04-05 12:00	2014-04-03 10:00	2014-04-05 12:00	2014-05-08 10:00	2014-05-10 12:00	Y				N	NBMKc7UIikuQti6zqAf/Pw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:07		
+%R	89235	106256	4680	Y			10568			8	8	0.8	0	0.8	0	0	0		500.00	4000.00	0.00	0.00	4000.00			2014-04-03 10:00	2014-04-05 12:00	2014-04-03 10:00	2014-04-05 12:00	2014-05-08 10:00	2014-05-10 12:00	Y				N	xPigSRIVuk+nKqhGXGH8gg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:08		
+%R	89236	106256	4680	Y			10567			55	55	5.5	0	5.5	0	0	0		2.00	110.00	0.00	0.00	110.00			2014-04-03 10:00	2014-04-05 12:00	2014-04-03 10:00	2014-04-05 12:00	2014-05-08 10:00	2014-05-10 12:00	Y				N	hLItuyPLqUKNDRp0LVICiw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:08		
+%R	89237	106257	4680	Y			10579			34	34	0.85	0	0.85	0	0	0		120.00	4080.00	0.00	0.00	4080.00			2014-05-17 14:00	2014-05-22 14:00	2014-05-17 14:00	2014-05-22 14:00	2014-07-05 08:00	2014-07-09 16:00	Y				N	hJkSTw3Jn0+X/NvG/92dWQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 20:13		
+%R	89238	106258	4680	Y			10568			3	3	0.03	0	0.03	0	0	0		500.00	1500.00	0.00	0.00	1500.00			2014-03-22 08:00	2014-04-05 12:00	2014-03-22 08:00	2014-04-05 12:00	2014-12-29 12:00	2015-01-12 16:00	Y				N	7qnwrGVfo0GSfLao53Fahw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:13		
+%R	89239	106258	4680	Y			10570			9	9	0.9	0	0.9	0	0	0		12.00	108.00	0.00	0.00	108.00			2014-03-22 08:00	2014-03-23 10:00	2014-03-22 08:00	2014-03-23 10:00	2015-01-11 14:00	2015-01-12 16:00	Y				N	IcnyrnNaBE+oBhgdxfLNXg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:13		
+%R	89240	106258	4680	Y			10576			0.3	0.3	0.03	0	0.03	0	0	0		750.00	225.00	0.00	0.00	225.00			2014-03-22 08:00	2014-03-23 10:00	2014-03-22 08:00	2014-03-23 10:00	2015-01-11 14:00	2015-01-12 16:00	Y				N	fEatwJZKnEuicbAQoQjUQQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:14		
+%R	89241	106258	4680	N			10575			290	290	29	0	29	0	0	0		0.00	23200.00	0.00	0.00	23200.00			2014-03-22 08:00	2014-03-23 10:00	2014-03-22 08:00	2014-03-23 10:00	2015-01-11 14:00	2015-01-12 16:00	Y				N	VuKRs2RcG06KD+z3yL7wyg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:14		
+%R	89242	106258	4680	N			10574			290	290	2.9	0	2.9	0	0	0		0.00	4930.00	0.00	0.00	4930.00			2014-03-22 08:00	2014-04-05 12:00	2014-03-22 08:00	2014-04-05 12:00	2014-12-29 12:00	2015-01-12 16:00	Y				N	mal+sTL0xUeozeqfOdlVkA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 20:14		
+%R	89243	106258	4680	Y			10567			12	12	1.2	0	1.2	0	0	0		2.00	24.00	0.00	0.00	24.00			2014-03-22 08:00	2014-03-23 10:00	2014-03-22 08:00	2014-03-23 10:00	2015-01-11 14:00	2015-01-12 16:00	Y				N	0jv5pnUj/UuEB/liCfyC2g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:20		
+%R	89244	106259	4680	Y			10578			288	288	1.92	0	1.92	0	0	0		50.00	14400.00	0.00	0.00	14400.00			2014-06-30 10:00	2014-07-21 16:00	2014-06-30 10:00	2014-07-21 16:00	2014-08-11 12:00	2014-09-02 10:00	Y				N	uxsmQFaUA0KEfdGOcqpoeQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:22		
+%R	89245	106259	4680	Y			10577			1440	1440	9.6	0	9.6	0	0	0		12.00	17280.00	0.00	0.00	17280.00			2014-06-30 10:00	2014-07-21 16:00	2014-06-30 10:00	2014-07-21 16:00	2014-08-11 12:00	2014-09-02 10:00	Y				N	wb5iMMzeSke+tno0xMU3Aw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 20:22		
+%R	89246	106261	4680	Y			10571			14	14	0.1	0	0.1	0	0	0		200.00	2800.00	0.00	0.00	2800.00			2014-04-05 12:00	2014-04-24 16:00	2014-04-05 12:00	2014-04-24 16:00	2014-05-22 14:00	2014-06-12 10:00	Y				N	mD07MumYckKGfUs80PnkUw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:25		
+%R	89247	106262	4680	N			10572			2768	2768	10.64615385	0	10.64615385	0	0	0		0.00	31045.00	0.00	0.00	31045.00			2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	Y				N	qieu2H2qfEiF9kc8pha+4w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 20:48		
+%R	89248	106262	4680	Y			10570			28	28	2.8	0	2.8	0	0	0		12.00	336.00	0.00	0.00	336.00			2014-05-10 12:00	2014-05-11 14:00	2014-05-10 12:00	2014-05-11 14:00	2014-06-15 14:00	2014-06-16 16:00	Y				N	9BkiSTIJUkWvkZGWpevaXA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:48		
+%R	89250	106262	4680	Y			10567			56	56	5.6	0	5.6	0	0	0		2.00	112.00	0.00	0.00	112.00			2014-05-10 12:00	2014-05-11 14:00	2014-05-10 12:00	2014-05-11 14:00	2014-06-15 14:00	2014-06-16 16:00	Y				N	xJkLYbde5kq309CB/sG1og	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:48		
+%R	89251	106262	4680	Y			10568			8.5	8.5	0.85	0	0.85	0	0	0		500.00	4250.00	0.00	0.00	4250.00			2014-05-10 12:00	2014-05-11 14:00	2014-05-10 12:00	2014-05-11 14:00	2014-06-15 14:00	2014-06-16 16:00	Y				N	9FcijaWHVk6HCgn/EstkKQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:48		
+%R	89252	106263	4680	Y			10579			36	36	0.9	0	0.9	0	0	0		120.00	4320.00	0.00	0.00	4320.00			2014-06-24 10:00	2014-06-30 10:00	2014-06-24 10:00	2014-06-30 10:00	2014-08-05 12:00	2014-08-11 12:00	Y				N	8D6eWFHnU0+AJOiif1OfsA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 20:54		
+%R	89253	106264	4680	N			10575			395	395	39.5	0	39.5	0	0	0		0.00	31600.00	0.00	0.00	31600.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	HQnwgWdjUkGvdQmiDhU37w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:59		
+%R	89254	106264	4680	Y			10576			0.1	0.1	0.01	0	0.01	0	0	0		750.00	75.00	0.00	0.00	75.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	tMleWf4/B0GFt97Rw5Jz0g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:59		
+%R	89255	106264	4680	Y			10568			4	4	0.4	0	0.4	0	0	0		500.00	2000.00	0.00	0.00	2000.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	RyB+JZ/rP0iDEPWHPJLqOw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:59		
+%R	89256	106264	4680	Y			10567			16	16	1.6	0	1.6	0	0	0		2.00	32.00	0.00	0.00	32.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	I/W/zDGAnkCf0m17s3yd4g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:59		
+%R	89257	106264	4680	Y			10570			12	12	1.2	0	1.2	0	0	0		12.00	144.00	0.00	0.00	144.00			2014-04-14 08:00	2014-04-15 10:00	2014-04-14 08:00	2014-04-15 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	8qDnsN4w20W2uiUjoCMwAw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 20:59		
+%R	89258	106264	4680	N			10574			395	395	3.95	0	3.95	0	0	0		0.00	7110.00	0.00	0.00	7110.00			2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2015-01-13 08:00	2015-01-27 12:00	Y				N	gfNLtaJ190OCPx0mb3/wlA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 20:59		
+%R	89259	106265	4680	Y			10577			18408	18408	115.05	0	115.05	0	0	0		12.00	220896.00	0.00	0.00	220896.00			2014-08-03 08:00	2014-08-25 16:00	2014-08-03 08:00	2014-08-25 16:00	2014-09-02 10:00	2014-09-25 10:00	Y				N	cEnxaMXUmEi5HsAN7IMpqw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:02		
+%R	89260	106265	4680	Y			10578			307	307	1.91875	0	1.91875	0	0	0		50.00	15350.00	0.00	0.00	15350.00			2014-08-03 08:00	2014-08-25 16:00	2014-08-03 08:00	2014-08-25 16:00	2014-09-02 10:00	2014-09-25 10:00	Y				N	zNTTrw0vc02/XfgSOymjZw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:02		
+%R	89261	106267	4680	Y			10571			166	166	1.18571429	0	1.18571429	0	0	0		200.00	33200.00	0.00	0.00	33200.00			2014-04-28 12:00	2014-05-18 16:00	2014-04-28 12:00	2014-05-18 16:00	2014-06-12 10:00	2014-07-02 14:00	Y				N	j+2cti0PZ02V8Ej/KFKK/Q	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:17		
+%R	89262	106268	4680	N			10572			2380	2380	10.34782609	0	10.34782609	0	0	0		0.00	33320.00	0.00	0.00	33320.00			2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	Y				N	dxMlX5rvAE6hROXL1Wfcog	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:18		
+%R	89263	106268	4680	Y			10570			24	24	2.4	0	2.4	0	0	0		12.00	288.00	0.00	0.00	288.00			2014-06-17 08:00	2014-06-18 10:00	2014-06-17 08:00	2014-06-18 10:00	2014-07-19 12:00	2014-07-20 14:00	Y				N	ToGiwenKh0WKwB+Z+GlqDw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:18		
+%R	89264	106268	4680	Y			10568			7.5	7.5	0.75	0	0.75	0	0	0		500.00	3750.00	0.00	0.00	3750.00			2014-06-17 08:00	2014-06-18 10:00	2014-06-17 08:00	2014-06-18 10:00	2014-07-19 12:00	2014-07-20 14:00	Y				N	slSSamfz3Eay6pByrDgoiw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:18		
+%R	89265	106268	4680	Y			10567			48	48	4.8	0	4.8	0	0	0		2.00	96.00	0.00	0.00	96.00			2014-06-17 08:00	2014-06-18 10:00	2014-06-17 08:00	2014-06-18 10:00	2014-07-19 12:00	2014-07-20 14:00	Y				N	W0vKFsd4dk66HyV+58937g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:18		
+%R	89266	106269	4680	Y			10579			30	30	0.75	0	0.75	0	0	0		120.00	3600.00	0.00	0.00	3600.00			2014-07-28 08:00	2014-08-02 16:00	2014-07-28 08:00	2014-08-02 16:00	2014-08-27 10:00	2014-09-02 10:00	Y				N	bUQknsU5fEy/kuMYF6eG0w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:22		
+%R	89267	106270	4680	N			10574			360	360	3.27272727	0	3.27272727	0	0	0		0.00	28800.00	0.00	0.00	28800.00			2014-05-08 10:00	2014-05-24 16:00	2014-05-08 10:00	2014-05-24 16:00	2015-01-27 12:00	2015-02-12 10:00	Y				N	kTJPOn9lSEG6J+zlBZEz+A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:23		
+%R	89268	106270	4680	Y			10567			15	15	1.5	0	1.5	0	0	0		2.00	30.00	0.00	0.00	30.00			2014-05-08 10:00	2014-05-10 12:00	2014-05-08 10:00	2014-05-10 12:00	2015-02-11 08:00	2015-02-12 10:00	Y				N	+b6khZKmSESzp8h/ybdeIg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:23		
+%R	89269	106270	4680	Y			10568			3.6	3.6	0.36	0	0.36	0	0	0		500.00	1800.00	0.00	0.00	1800.00			2014-05-08 10:00	2014-05-10 12:00	2014-05-08 10:00	2014-05-10 12:00	2015-02-11 08:00	2015-02-12 10:00	Y				N	1Ph95zObFkWDNHVoPwzdYQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:23		
+%R	89270	106270	4680	Y			10570			11	11	1.1	0	1.1	0	0	0		12.00	132.00	0.00	0.00	132.00			2014-05-08 10:00	2014-05-10 12:00	2014-05-08 10:00	2014-05-10 12:00	2015-02-11 08:00	2015-02-12 10:00	Y				N	aeoEMkIadEmfLgt3hOUmuQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:23		
+%R	89271	106270	4680	Y			10576			0.36	0.36	0.036	0	0.036	0	0	0		750.00	270.00	0.00	0.00	270.00			2014-05-08 10:00	2014-05-10 12:00	2014-05-08 10:00	2014-05-10 12:00	2015-02-11 08:00	2015-02-12 10:00	Y				N	PQwqsDlT1Eqfn5HGYqn3kA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:24		
+%R	89273	106271	4680	Y			10578			262	262	2.91111111	0	2.91111111	0	0	0		50.00	13100.00	0.00	0.00	13100.00			2014-08-26 08:00	2014-09-08 10:00	2014-08-26 08:00	2014-09-08 10:00	2014-09-25 10:00	2014-10-08 12:00	Y				N	+rFIW6/Y9U6IT4R9/yoWMw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:26		
+%R	89274	106271	4680	Y			10577			90	90	1	0	1	0	0	0		12.00	1080.00	0.00	0.00	1080.00			2014-08-26 08:00	2014-09-08 10:00	2014-08-26 08:00	2014-09-08 10:00	2014-09-25 10:00	2014-10-08 12:00	Y				N	hmnv12b94Ei49mO5zH3BNA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:26		
+%R	89275	106273	4680	Y			10571			4	4	0.05714286	0	0.05714286	0	0	0		200.00	800.00	0.00	0.00	800.00			2014-05-19 08:00	2014-05-28 14:00	2014-05-19 08:00	2014-05-28 14:00	2014-07-07 12:00	2014-07-17 10:00	Y				N	qNQIIrs2skOvou0T6tb0DA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:28		
+%R	89276	106274	4680	N			10572			720	720	9	0	9	0	0	0		0.00	10080.00	0.00	0.00	10080.00			2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	Y				N	N/adRdMU20CVHKlZIg8qdQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:28		
+%R	89277	106274	4680	Y			10570			10	10	1	0	1	0	0	0		12.00	120.00	0.00	0.00	120.00			2014-07-20 14:00	2014-07-21 16:00	2014-07-20 14:00	2014-07-21 16:00	2014-07-30 12:00	2014-07-31 14:00	Y				N	NfwqDp4SskCdQqaL7Ct/Iw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:28		
+%R	89278	106274	4680	Y			10567			20	20	2	0	2	0	0	0		2.00	40.00	0.00	0.00	40.00			2014-07-20 14:00	2014-07-21 16:00	2014-07-20 14:00	2014-07-21 16:00	2014-07-30 12:00	2014-07-31 14:00	Y				N	8e7hjblsgUuHmgtKAwRo9A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:28		
+%R	89279	106274	4680	Y			10568			2.2	2.2	0.22	0	0.22	0	0	0		500.00	1100.00	0.00	0.00	1100.00			2014-07-20 14:00	2014-07-21 16:00	2014-07-20 14:00	2014-07-21 16:00	2014-07-30 12:00	2014-07-31 14:00	Y				N	4+ovJQd+5UmOYtgPapsZsw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:28		
+%R	89281	106275	4680	Y			10579			20	20	0.5	0	0.5	0	0	0		120.00	2400.00	0.00	0.00	2400.00			2014-08-09 08:00	2014-08-13 16:00	2014-08-09 08:00	2014-08-13 16:00	2014-09-20 10:00	2014-09-25 10:00	Y				N	XNqW2SpNYkanuQ+IiQS5ZA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:30		
+%R	89282	106279	4680	N			10572			1280	1280	7.52941176	0	7.52941176	0	0	0		0.00	25600.00	0.00	0.00	25600.00			2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	Y				N	f1zuWcYbmUCeXqBX3TgCtQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:31		
+%R	89283	106279	4680	Y			10570			15	15	1.5	0	1.5	0	0	0		12.00	180.00	0.00	0.00	180.00			2014-07-31 14:00	2014-08-02 16:00	2014-07-31 14:00	2014-08-02 16:00	2014-08-24 14:00	2014-08-25 16:00	Y				N	kXYFoBzRWkqpbqnogE1aNQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:32		
+%R	89284	106279	4680	Y			10568			3.85	3.85	0.385	0	0.385	0	0	0		500.00	1925.00	0.00	0.00	1925.00			2014-07-31 14:00	2014-08-02 16:00	2014-07-31 14:00	2014-08-02 16:00	2014-08-24 14:00	2014-08-25 16:00	Y				N	nmcLuXvuJk+EwAdX3on9uQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:32		
+%R	89285	106279	4680	Y			10567			30	30	3	0	3	0	0	0		2.00	60.00	0.00	0.00	60.00			2014-07-31 14:00	2014-08-02 16:00	2014-07-31 14:00	2014-08-02 16:00	2014-08-24 14:00	2014-08-25 16:00	Y				N	o5MNqdi2LU6nywFTpF6zFQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:32		
+%R	89286	106280	4680	Y			10580			1000	1000	7.14285714	0	7.14285714	0	0	0	0	12.00	12000.00	0.00	0.00	12000.00			2014-08-26 08:00	2014-09-15 12:00	2014-08-26 08:00	2014-09-15 12:00	2015-01-22 14:00	2015-02-12 10:00	Y				N	/T69s/NDrkaerdMCP98nFA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:37		
+%R	89287	106281	4680	N			10572			4000	4000	7.27272727	0	7.27272727	0	0	0		0.00	80000.00	0.00	0.00	80000.00			2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	Y				N	jDbyMAODn02QyxyWEeCgjA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-01 21:49		
+%R	89288	106281	4680	Y			10567			80	80	8	0	8	0	0	0		2.00	160.00	0.00	0.00	160.00			2014-08-26 08:00	2014-08-27 10:00	2014-08-26 08:00	2014-08-27 10:00	2014-11-12 12:00	2014-11-13 14:00	Y				N	hesVp424+U+ZKMM6kEqjtw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:49		
+%R	89289	106281	4680	Y			10570			40	40	4	0	4	0	0	0		12.00	480.00	0.00	0.00	480.00			2014-08-26 08:00	2014-08-27 10:00	2014-08-26 08:00	2014-08-27 10:00	2014-11-12 12:00	2014-11-13 14:00	Y				N	A4xTqlCq+k2dvHKkJcch9g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:49		
+%R	89290	106281	4680	Y			10568			12	12	1.2	0	1.2	0	0	0		500.00	6000.00	0.00	0.00	6000.00			2014-08-26 08:00	2014-08-27 10:00	2014-08-26 08:00	2014-08-27 10:00	2014-11-12 12:00	2014-11-13 14:00	Y				N	nwJI7NnpPEa9qZOwPUTuAg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-01 21:49		
+%R	89291	106282	4680	Y			10582			60	60	1.2	0	1.2	0	0	0		35.00	2100.00	0.00	0.00	2100.00			2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2015-02-12 10:00	2015-02-19 12:00	Y				N	aTZpHxpPuUqR7xTq1HKGnQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:34		
+%R	89292	106282	4680	Y			10568			0.6	0.6	0.06	0	0.06	0	0	0		500.00	300.00	0.00	0.00	300.00			2014-11-13 14:00	2014-11-15 16:00	2014-11-13 14:00	2014-11-15 16:00	2015-02-18 10:00	2015-02-19 12:00	Y				N	vn1pk7qjNk6f64krSo6npg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:34		
+%R	89293	106282	4680	Y			10570			0.5	0.5	0.05	0	0.05	0	0	0		12.00	6.00	0.00	0.00	6.00			2014-11-13 14:00	2014-11-15 16:00	2014-11-13 14:00	2014-11-15 16:00	2015-02-18 10:00	2015-02-19 12:00	Y				N	CR1ddOaU5UW6E3ulodJ6kw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:34		
+%R	89294	106282	4680	Y			10567			2	2	0.2	0	0.2	0	0	0		2.00	4.00	0.00	0.00	4.00			2014-11-13 14:00	2014-11-15 16:00	2014-11-13 14:00	2014-11-15 16:00	2015-02-18 10:00	2015-02-19 12:00	Y				N	HeTe3hSi/0ix+jd6VbNBtA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:34		
+%R	89295	106282	4680	Y			10581			60	60	6	0	6	0	0	0		90.00	5400.00	0.00	0.00	5400.00			2014-11-13 14:00	2014-11-15 16:00	2014-11-13 14:00	2014-11-15 16:00	2015-02-18 10:00	2015-02-19 12:00	Y				N	hHv4nmaX/kWvHWrMmuIPDg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:34		
+%R	89296	106276	4680	Y			10569			552	552	55.2	0	55.2	0	0	0		25.00	13800.00	0.00	0.00	13800.00			2014-07-31 14:00	2014-08-02 16:00	2014-07-31 14:00	2014-08-02 16:00	2015-01-05 14:00	2015-01-06 16:00	Y				N	PmUrXGd/8U6VPxbgL8eMEA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:39		
+%R	89297	106276	4680	Y			10583			552	552	13.8	0	13.8	0	0	0		10.00	5520.00	0.00	0.00	5520.00			2014-07-31 14:00	2014-08-06 14:00	2014-07-31 14:00	2014-08-06 14:00	2015-01-01 08:00	2015-01-06 16:00	Y				N	LOF1J4iwHUiphhkIZqetBA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:40		
+%R	89298	106277	4680	Y			10584			552	552	13.8	0	13.8	0	0	0		50.00	27600.00	0.00	0.00	27600.00			2014-08-06 14:00	2014-08-12 14:00	2014-08-06 14:00	2014-08-12 14:00	2015-01-07 08:00	2015-01-12 16:00	Y				N	KEYJEwtB9EeeRltOD5v2jA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:40		
+%R	89299	106283	4680	Y			10585			26	26	0.18571429	0	0.18571429	0	0	0		150.00	3900.00	0.00	0.00	3900.00			2014-05-04 12:00	2014-05-24 16:00	2014-05-04 12:00	2014-05-24 16:00	2014-09-27 12:00	2014-10-16 16:00	Y				N	62eJU+LwJ0y/BQSgqWO9RA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:42		
+%R	89300	106284	4680	Y			10578			60	60	6	0	6	0	0	0		50.00	3000.00	0.00	0.00	3000.00			2014-05-25 08:00	2014-05-26 10:00	2014-05-25 08:00	2014-05-26 10:00	2014-10-30 10:00	2014-11-01 12:00	Y				N	pYSJrT3cIUOXEMIT0utrGw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:42		
+%R	89301	106284	4680	Y			10577			600	600	6	0	6	0	0	0		12.00	7200.00	0.00	0.00	7200.00			2014-05-25 08:00	2014-06-08 12:00	2014-05-25 08:00	2014-06-08 12:00	2014-10-18 08:00	2014-11-01 12:00	Y				N	2f/H/nFdD0my4CEojLEc3Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:42		
+%R	89302	106285	4680	Y			10586			68	68	0.97142857	0	0.97142857	0	0	0		15.00	1020.00	0.00	0.00	1020.00			2014-06-03 14:00	2014-06-14 12:00	2014-06-03 14:00	2014-06-14 12:00	2014-08-09 08:00	2014-08-18 14:00	Y				N	9tAvIU3Q1UidPHZFTzWNBw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:44		
+%R	89303	106286	4680	Y			10587			256	256	25.6	0	25.6	0	0	0		80.00	20480.00	0.00	0.00	20480.00			2014-06-03 14:00	2014-06-04 16:00	2014-06-03 14:00	2014-06-04 16:00	2014-08-21 10:00	2014-08-23 12:00	Y				N	J7Xruqx0U06ieguJPWULCQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:45		
+%R	89304	106286	4680	Y			10570			26	26	2.6	0	2.6	0	0	0		12.00	312.00	0.00	0.00	312.00			2014-06-03 14:00	2014-06-04 16:00	2014-06-03 14:00	2014-06-04 16:00	2014-08-21 10:00	2014-08-23 12:00	Y				N	VM+SUDaN/EqBAbRFRXESkg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:45		
+%R	89305	106286	4680	Y			10568			2	2	0.2	0	0.2	0	0	0		500.00	1000.00	0.00	0.00	1000.00			2014-06-03 14:00	2014-06-04 16:00	2014-06-03 14:00	2014-06-04 16:00	2014-08-21 10:00	2014-08-23 12:00	Y				N	hbZzJfXvsEiKEmA/PS27GA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:45		
+%R	89306	106286	4680	Y			10567			13	13	1.3	0	1.3	0	0	0		2.00	26.00	0.00	0.00	26.00			2014-06-03 14:00	2014-06-04 16:00	2014-06-03 14:00	2014-06-04 16:00	2014-08-21 10:00	2014-08-23 12:00	Y				N	ltsQXC9EUU+i/TmsGOdLow	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:45		
+%R	89308	106286	4680	Y			10582			256	256	2.56	0	2.56	0	0	0		35.00	8960.00	0.00	0.00	8960.00			2014-06-03 14:00	2014-06-18 10:00	2014-06-03 14:00	2014-06-18 10:00	2014-08-09 08:00	2014-08-23 12:00	Y				N	+NPj4fjE9kCHnplYHQStAA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:45		
+%R	89309	106287	4680	Y			10588			324	324	4.62857143	0	4.62857143	0	0	0		3.00	972.00	0.00	0.00	972.00			2014-06-03 14:00	2014-06-14 12:00	2014-06-03 14:00	2014-06-14 12:00	2014-08-09 08:00	2014-08-18 14:00	Y				N	3YAew+4fr0W8+wUqJzaqZg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:48		
+%R	89311	106288	4680	Y			10589			74	74	0.35238095	0	0.35238095	0	0	0		150.00	11100.00	0.00	0.00	11100.00			2014-05-04 12:00	2014-06-03 14:00	2014-05-04 12:00	2014-06-03 14:00	2014-07-08 14:00	2014-08-07 16:00	Y				N	v6hajL3i0EeW0ifXKdkTcQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:53		
+%R	89312	106289	4680	Y			10585			21	21	0.1	0	0.1	0	0	0		150.00	3150.00	0.00	0.00	3150.00			2014-06-14 12:00	2014-07-14 14:00	2014-06-14 12:00	2014-07-14 14:00	2014-08-18 14:00	2014-09-17 16:00	Y				N	70tWc1PDu0iZvfdaVepaWQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:54		
+%R	89313	106290	4680	Y			10578			100	100	0.90909091	0	0.90909091	0	0	0		50.00	5000.00	0.00	0.00	5000.00			2014-07-14 14:00	2014-07-30 12:00	2014-07-14 14:00	2014-07-30 12:00	2014-11-01 12:00	2014-11-17 10:00	Y				N	S3QWCz9CdU6KpGRqId1ELQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:54		
+%R	89314	106290	4680	Y			10577			992	992	9.01818182	0	9.01818182	0	0	0		12.00	11904.00	0.00	0.00	11904.00			2014-07-14 14:00	2014-07-30 12:00	2014-07-14 14:00	2014-07-30 12:00	2014-11-01 12:00	2014-11-17 10:00	Y				N	4En9XJ9B80WSE/pHLEhJqQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:55		
+%R	89315	106291	4680	Y			10586			216	216	1.54285714	0	1.54285714	0	0	0		15.00	3240.00	0.00	0.00	3240.00			2014-07-22 08:00	2014-08-11 12:00	2014-07-22 08:00	2014-08-11 12:00	2014-09-08 10:00	2014-09-28 14:00	Y				N	fd/wDfWe+U2QBQVIW44UvQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:55		
+%R	89317	106292	4680	Y			10587			214	214	21.4	0	21.4	0	0	0		80.00	17120.00	0.00	0.00	17120.00			2014-07-22 08:00	2014-07-23 10:00	2014-07-22 08:00	2014-07-23 10:00	2014-09-16 14:00	2014-09-17 16:00	Y				N	kCyrXfcTM02vEgs56Ubv2g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:56		
+%R	89318	106292	4680	Y			10570			22	22	2.2	0	2.2	0	0	0		12.00	264.00	0.00	0.00	264.00			2014-07-22 08:00	2014-07-23 10:00	2014-07-22 08:00	2014-07-23 10:00	2014-09-16 14:00	2014-09-17 16:00	Y				N	NP7iR1gDf0iM0Fyned2+jA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:56		
+%R	89319	106292	4680	Y			10568			2.5	2.5	0.25	0	0.25	0	0	0		500.00	1250.00	0.00	0.00	1250.00			2014-07-22 08:00	2014-07-23 10:00	2014-07-22 08:00	2014-07-23 10:00	2014-09-16 14:00	2014-09-17 16:00	Y				N	pxrpg79v2U+1AGmlH8pb0Q	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:56		
+%R	89320	106292	4680	Y			10567			11	11	1.1	0	1.1	0	0	0		2.00	22.00	0.00	0.00	22.00			2014-07-22 08:00	2014-07-23 10:00	2014-07-22 08:00	2014-07-23 10:00	2014-09-16 14:00	2014-09-17 16:00	Y				N	9P1D292gCky3+Q6x77lx3Q	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 20:56		
+%R	89321	106292	4680	Y			10582			214	214	3.05714286	0	3.05714286	0	0	0		35.00	7490.00	0.00	0.00	7490.00			2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-09-08 10:00	2014-09-17 16:00	Y				N	7YPB3ToLZEiR4r93DSHo8A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:56		
+%R	89322	106293	4680	Y			10588			430	430	6.14285714	0	6.14285714	0	0	0		3.00	1290.00	0.00	0.00	1290.00			2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-09-08 10:00	2014-09-17 16:00	Y				N	G1/RWFcakkyZV5NUip8MAA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 20:59		
+%R	89323	106294	4680	Y			10589			130	130	0.61904762	0	0.61904762	0	0	0		150.00	19500.00	0.00	0.00	19500.00			2014-06-21 14:00	2014-07-21 16:00	2014-06-21 14:00	2014-07-21 16:00	2014-08-09 08:00	2014-09-08 10:00	Y				N	YMHdu6g4TUeqlqO0I2rJEQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:00		
+%R	89324	106295	4680	Y			10585			29	29	0.13809524	0	0.13809524	0	0	0		150.00	4350.00	0.00	0.00	4350.00			2014-07-31 14:00	2014-08-31 16:00	2014-07-31 14:00	2014-08-31 16:00	2014-09-18 08:00	2014-10-19 10:00	Y				N	xqh3cvB9s0ud1/d+9Hk+Qg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:00		
+%R	89325	106296	4680	Y			10578			145	145	1.45	0	1.45	0	0	0		50.00	7250.00	0.00	0.00	7250.00			2014-09-01 08:00	2014-09-15 12:00	2014-09-01 08:00	2014-09-15 12:00	2014-11-17 10:00	2014-12-01 14:00	Y				N	eE+RbRHLdUeA36BCH+LaaA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:00		
+%R	89326	106296	4680	Y			10577			1440	1440	14.4	0	14.4	0	0	0		12.00	17280.00	0.00	0.00	17280.00			2014-09-01 08:00	2014-09-15 12:00	2014-09-01 08:00	2014-09-15 12:00	2014-11-17 10:00	2014-12-01 14:00	Y				N	9f4qKPAN0ESCGNaHBJpW7A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:01		
+%R	89327	106297	4680	Y			10586			216	216	1.54285714	0	1.54285714	0	0	0		15.00	3240.00	0.00	0.00	3240.00			2014-08-21 10:00	2014-09-10 14:00	2014-08-21 10:00	2014-09-10 14:00	2014-10-08 12:00	2014-10-28 16:00	Y				N	cZCYBz0ZrEeF/YUQ8FEgdg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:04		
+%R	89328	106298	4680	Y			10587			200	200	4	0	4	0	0	0		80.00	16000.00	0.00	0.00	16000.00			2014-08-21 10:00	2014-08-28 12:00	2014-08-21 10:00	2014-08-28 12:00	2014-10-08 12:00	2014-10-15 14:00	Y				N	Jqywjk/VDEWo40yMiRM88g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:05		
+%R	89329	106298	4680	Y			10570			40	40	4	0	4	0	0	0		12.00	480.00	0.00	0.00	480.00			2014-08-21 10:00	2014-08-23 12:00	2014-08-21 10:00	2014-08-23 12:00	2014-10-14 12:00	2014-10-15 14:00	Y				N	IbCBGLqTjUu8HIpPugPgHA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:05		
+%R	89330	106298	4680	Y			10568			2	2	0.2	0	0.2	0	0	0		500.00	1000.00	0.00	0.00	1000.00			2014-08-21 10:00	2014-08-23 12:00	2014-08-21 10:00	2014-08-23 12:00	2014-10-14 12:00	2014-10-15 14:00	Y				N	s1qOSlAGJEu8L3hjFN5h4g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:05		
+%R	89332	106298	4680	Y			10582			200	200	20	0	20	0	0	0		35.00	7000.00	0.00	0.00	7000.00			2014-08-21 10:00	2014-08-23 12:00	2014-08-21 10:00	2014-08-23 12:00	2014-10-14 12:00	2014-10-15 14:00	Y				N	QXVv2LbBCkCbF+ppVfhi1w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:05		
+%R	89333	106298	4680	Y			10567			10	10	1	0	1	0	0	0		2.00	20.00	0.00	0.00	20.00			2014-08-21 10:00	2014-08-23 12:00	2014-08-21 10:00	2014-08-23 12:00	2014-10-14 12:00	2014-10-15 14:00	Y				N	em/Pa/ud5UKepiUNGJP0WQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:07		
+%R	89334	106299	4680	Y			10588			416	416	5.94285714	0	5.94285714	0	0	0		3.00	1248.00	0.00	0.00	1248.00			2014-08-21 10:00	2014-08-31 16:00	2014-08-21 10:00	2014-08-31 16:00	2014-10-08 12:00	2014-10-19 10:00	Y				N	I0+Fl3cNeEORFg6IbtoSgg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:08		
+%R	89335	106300	4680	Y			10589			150	150	0.71428571	0	0.71428571	0	0	0		150.00	22500.00	0.00	0.00	22500.00			2014-07-22 08:00	2014-08-21 10:00	2014-07-22 08:00	2014-08-21 10:00	2014-09-08 10:00	2014-10-08 12:00	Y				N	molN4fDydEq+/7j9U1vfsg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:08		
+%R	89336	106301	4680	Y			10586			33	33	0.15714286	0	0.15714286	0	0	0		15.00	495.00	0.00	0.00	495.00			2014-09-01 08:00	2014-10-01 10:00	2014-09-01 08:00	2014-10-01 10:00	2014-10-19 10:00	2014-11-18 12:00	Y				N	z2fx8+gwfkenfr/j9Puzcg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:08		
+%R	89337	106302	4680	Y			10578			110	110	11	0	11	0	0	0		50.00	5500.00	0.00	0.00	5500.00			2014-10-01 10:00	2014-10-02 12:00	2014-10-01 10:00	2014-10-02 12:00	2014-12-16 10:00	2014-12-17 12:00	Y				N	37bKXWLTrEKpFbyp5BCC+g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:09		
+%R	89338	106302	4680	Y			10577			110	110	1	0	1	0	0	0		12.00	1320.00	0.00	0.00	1320.00			2014-10-01 10:00	2014-10-16 16:00	2014-10-01 10:00	2014-10-16 16:00	2014-12-01 14:00	2014-12-17 12:00	Y				N	jrrEZ9QQAUGDUZsOF4x+vQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:09		
+%R	89339	106303	4680	Y			10586			160	160	1.14285714	0	1.14285714	0	0	0		15.00	2400.00	0.00	0.00	2400.00			2014-10-08 12:00	2014-10-28 16:00	2014-10-08 12:00	2014-10-28 16:00	2014-11-08 14:00	2014-11-29 10:00	Y				N	sxoc2+ZpD0q6FaODsmCf6w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:12		
+%R	89341	106304	4680	Y			10587			230	230	23	0	23	0	0	0		80.00	18400.00	0.00	0.00	18400.00			2014-10-08 12:00	2014-10-09 14:00	2014-10-08 12:00	2014-10-09 14:00	2014-11-13 14:00	2014-11-15 16:00	Y				N	ZAZglh8nf0SbvgFsPJCkrA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:12		
+%R	89342	106304	4680	Y			10570			46	46	4.6	0	4.6	0	0	0		12.00	552.00	0.00	0.00	552.00			2014-10-08 12:00	2014-10-09 14:00	2014-10-08 12:00	2014-10-09 14:00	2014-11-13 14:00	2014-11-15 16:00	Y				N	T4TF0H4gWk6K5ckFm6FLaQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:12		
+%R	89343	106304	4680	Y			10568			2.5	2.5	0.25	0	0.25	0	0	0		500.00	1250.00	0.00	0.00	1250.00			2014-10-08 12:00	2014-10-09 14:00	2014-10-08 12:00	2014-10-09 14:00	2014-11-13 14:00	2014-11-15 16:00	Y				N	aJwm831JjEq76W3cMNiAUw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:12		
+%R	89344	106304	4680	Y			10567			23	23	2.3	0	2.3	0	0	0		2.00	46.00	0.00	0.00	46.00			2014-10-08 12:00	2014-10-09 14:00	2014-10-08 12:00	2014-10-09 14:00	2014-11-13 14:00	2014-11-15 16:00	Y				N	dqNNhOFgtk2uSs3orvdNyA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:12		
+%R	89345	106304	4680	Y			10582			230	230	4.6	0	4.6	0	0	0		35.00	8050.00	0.00	0.00	8050.00			2014-10-08 12:00	2014-10-15 14:00	2014-10-08 12:00	2014-10-15 14:00	2014-11-08 14:00	2014-11-15 16:00	Y				N	13huiZku+UWMlu3VZIZyfA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:12		
+%R	89346	106305	4680	Y			10588			380	380	5.42857143	0	5.42857143	0	0	0		3.00	1140.00	0.00	0.00	1140.00			2014-10-08 12:00	2014-10-19 10:00	2014-10-08 12:00	2014-10-19 10:00	2014-11-08 14:00	2014-11-18 12:00	Y				N	cdwY8elw+EeDZhFR06j7kg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:13		
+%R	89347	106306	4680	Y			10589			144	144	0.68571429	0	0.68571429	0	0	0		150.00	21600.00	0.00	0.00	21600.00			2014-09-08 10:00	2014-10-08 12:00	2014-09-08 10:00	2014-10-08 12:00	2014-10-08 12:00	2014-11-08 14:00	Y				N	5SpefkIQJ0Cjz8gw0r+1VQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:14		
+%R	89348	106307	4680	Y			10585			23	23	0.10952381	0	0.10952381	0	0	0		150.00	3450.00	0.00	0.00	3450.00			2014-10-19 10:00	2014-11-18 12:00	2014-10-19 10:00	2014-11-18 12:00	2014-11-18 12:00	2014-12-18 14:00	Y				N	GAQCz54o70CAQc9o7zGeDA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:14		
+%R	89349	106308	4680	Y			10578			132	132	13.2	0	13.2	0	0	0		50.00	6600.00	0.00	0.00	6600.00			2014-11-18 12:00	2014-11-19 14:00	2014-11-18 12:00	2014-11-19 14:00	2014-12-30 14:00	2014-12-31 16:00	Y				N	tDSJY+qwS0Ok69mP6hDWgw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:15		
+%R	89350	106308	4680	Y			10577			1310	1310	14.55555556	0	14.55555556	0	0	0		12.00	15720.00	0.00	0.00	15720.00			2014-11-18 12:00	2014-12-01 14:00	2014-11-18 12:00	2014-12-01 14:00	2014-12-18 14:00	2014-12-31 16:00	Y				N	JZErS67Ng026aCVXNVvWyA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:15		
+%R	89351	106309	4680	Y			10590			680	680	68	0	68	0	0	0		12.00	8160.00	0.00	0.00	8160.00			2014-08-14 08:00	2014-08-16 10:00	2014-08-14 08:00	2014-08-16 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	Tn8NSUYXYkSHo+1bQ2S5kg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:17		
+%R	89352	106309	4680	Y			10570			75	75	7.5	0	7.5	0	0	0		12.00	900.00	0.00	0.00	900.00			2014-08-14 08:00	2014-08-16 10:00	2014-08-14 08:00	2014-08-16 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	1nUFKUUfOUmLbIGe0EjSkQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:18		
+%R	89353	106309	4680	Y			10568			7	7	0.7	0	0.7	0	0	0		500.00	3500.00	0.00	0.00	3500.00			2014-08-14 08:00	2014-08-16 10:00	2014-08-14 08:00	2014-08-16 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	qIgUagiGG0G4L/QbLafw9w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:18		
+%R	89354	106309	4680	Y			10567			30	30	3	0	3	0	0	0		2.00	60.00	0.00	0.00	60.00			2014-08-14 08:00	2014-08-16 10:00	2014-08-14 08:00	2014-08-16 10:00	2015-01-26 10:00	2015-01-27 12:00	Y				N	1n2OoiPjykOBUw+/FGPXJA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:18		
+%R	89355	106309	4680	Y			10582			680	680	7.55555556	0	7.55555556	0	0	0		35.00	23800.00	0.00	0.00	23800.00			2014-08-14 08:00	2014-08-27 10:00	2014-08-14 08:00	2014-08-27 10:00	2015-01-14 10:00	2015-01-27 12:00	Y				N	I0ThHogQd0eoql6x8LFXbw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:18		
+%R	89356	106310	4680	N			10572			360	360	4	0	4	0	0	0		0.00	4320.00	0.00	0.00	4320.00			2014-08-27 10:00	2014-09-09 12:00	2014-08-27 10:00	2014-09-09 12:00	2015-01-27 12:00	2015-02-09 14:00	Y				N	wpcMPaMbvkCT2TtVhMkm3A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:19		
+%R	89357	106310	4680	Y			10567			40	40	4	0	4	0	0	0		2.00	80.00	0.00	0.00	80.00			2014-08-27 10:00	2014-08-28 12:00	2014-08-27 10:00	2014-08-28 12:00	2015-02-08 12:00	2015-02-09 14:00	Y				N	8MgIiuwMlE6oOvSJ23Cufg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:19		
+%R	89358	106310	4680	Y			10592			4	4	0.4	0	0.4	0	0	0		1000.00	4000.00	0.00	0.00	4000.00			2014-08-27 10:00	2014-08-28 12:00	2014-08-27 10:00	2014-08-28 12:00	2015-02-08 12:00	2015-02-09 14:00	Y				N	Xn09LC0PM0CdiLMVSv2QYA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:21		
+%R	89359	106311	4680	Y			10585			4	4	0.05714286	0	0.05714286	0	0	0		150.00	600.00	0.00	0.00	600.00			2014-11-18 12:00	2014-11-29 10:00	2014-11-18 12:00	2014-11-29 10:00	2015-02-09 14:00	2015-02-19 12:00	Y				N	4yOMcCgXOEyyXfGz9c0//A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:22		
+%R	89360	106312	4680	Y			10580			1400	1400	6.66666667	0	6.66666667	0	0	0	0	12.00	16800.00	0.00	0.00	16800.00			2014-07-26 14:00	2014-08-25 16:00	2014-07-26 14:00	2014-08-25 16:00	2014-07-26 14:00	2014-08-25 16:00	Y				N	FV2UM3AjVUq8jmjhOrxTiQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:23		
+%R	89361	106313	4680	N			10572			640	640	4.92307692	0	4.92307692	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-02 10:00	2014-09-21 12:00	2014-09-02 10:00	2014-09-21 12:00	2014-12-15 08:00	2015-01-03 10:00	Y				N	zZDgyd0HuEuwlr9SrkcENA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:23		
+%R	89362	106313	4680	Y			10567			50	50	5	0	5	0	0	0		2.00	100.00	0.00	0.00	100.00			2014-09-02 10:00	2014-09-03 12:00	2014-09-02 10:00	2014-09-03 12:00	2015-01-01 08:00	2015-01-03 10:00	Y				N	jRiFC1gItE6TcJH+edjhhA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:23		
+%R	89363	106313	4680	Y			10592			6.5	6.5	0.65	0	0.65	0	0	0		1000.00	6500.00	0.00	0.00	6500.00			2014-09-02 10:00	2014-09-03 12:00	2014-09-02 10:00	2014-09-03 12:00	2015-01-01 08:00	2015-01-03 10:00	Y				N	3o+81AtDRk+F+2ZkswtM4Q	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:23		
+%R	89369	106314	4680	Y			10567			20	20	2	0	2	0	0	0		2.00	40.00	0.00	0.00	40.00			2014-09-21 12:00	2014-09-22 14:00	2014-09-21 12:00	2014-09-22 14:00	2015-01-13 08:00	2015-01-14 10:00	Y				N	XgAe1gBAK02PBRMj6jBpog	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:28		
+%R	89370	106314	4680	Y			10568			1.5	1.5	0.15	0	0.15	0	0	0		500.00	750.00	0.00	0.00	750.00			2014-09-21 12:00	2014-09-22 14:00	2014-09-21 12:00	2014-09-22 14:00	2015-01-13 08:00	2015-01-14 10:00	Y				N	8cjOHcxFkUmL2wsTrM0v9A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:28		
+%R	89371	106314	4680	Y			10570			15	15	1.5	0	1.5	0	0	0		12.00	180.00	0.00	0.00	180.00			2014-09-21 12:00	2014-09-22 14:00	2014-09-21 12:00	2014-09-22 14:00	2015-01-13 08:00	2015-01-14 10:00	Y				N	luPrekW1C0qWsvsuov7IzQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:28		
+%R	89372	106314	4680	Y			10582			150	150	1.875	0	1.875	0	0	0		35.00	5250.00	0.00	0.00	5250.00			2014-09-21 12:00	2014-10-02 12:00	2014-09-21 12:00	2014-10-02 12:00	2015-01-03 10:00	2015-01-14 10:00	Y				N	hwER0dZIJUyxDTf4US7lNw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:28		
+%R	89373	106314	4680	Y			10587			150	150	15	0	15	0	0	0		80.00	12000.00	0.00	0.00	12000.00			2014-09-21 12:00	2014-09-22 14:00	2014-09-21 12:00	2014-09-22 14:00	2015-01-13 08:00	2015-01-14 10:00	Y				N	uzP9ge3QE0qm8E/Ig6WUmw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:28		
+%R	89374	106315	4680	Y			10593			170	170	1.88888889	0	1.88888889	0	0	0	0	50.00	8500.00	0.00	0.00	8500.00			2014-09-21 12:00	2014-10-04 14:00	2014-09-21 12:00	2014-10-04 14:00	2015-01-03 10:00	2015-01-15 12:00	Y				N	vxPM9gD5mk+88cGZdzh8zw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:29		
+%R	89375	106316	4680	N			10572			2000	2000	5	0	5	0	0	0		0.00	20000.00	0.00	0.00	20000.00			2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	Y				N	AvswRlEHDEi0Vgb+TZbvJw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:29		
+%R	89376	106316	4680	Y			10567			100	100	0.25	0	0.25	0	0	0		2.00	200.00	0.00	0.00	200.00			2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	Y				N	9Skh2r+HWEm8l8XVD3rMVA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:29		
+%R	89377	106316	4680	Y			10592			20	20	0.05	0	0.05	0	0	0		1000.00	20000.00	0.00	0.00	20000.00			2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	Y				N	8h97PrMn3UywaOVD534KVw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-02 21:30		
+%R	89378	106317	4680	N			10594			1	1	0.02	0	0.02	0	0	0		0.00	5000.00	0.00	0.00	5000.00			2015-01-19 08:00	2015-01-26 10:00	2015-01-19 08:00	2015-01-26 10:00	2015-01-19 08:00	2015-01-26 10:00	Y				N	xDUXf5gIJ0qMh3Fb34/bbw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-02 21:34		
+%R	89379	106318	4680	N			10596			2	2	0.02857143	0	0.02857143	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	Y				N	Ihd5Fp56KESOgLZ8/OL+1A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:47		
+%R	89380	106318	4680	N			10595			70	70	7	0	7	0	0	0		0.00	10000.00	0.00	0.00	10000.00			2014-02-03 08:00	2014-02-04 10:00	2014-02-03 08:00	2014-02-04 10:00	2014-02-11 12:00	2014-02-12 14:00	Y				N	yiN5lVMU8EKsjjT59YeJSA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:47		
+%R	89381	106319	4680	N			10596			30	30	1	0	1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-02-20 08:00	2014-02-24 14:00	2014-02-20 08:00	2014-02-24 14:00	2015-01-26 10:00	2015-01-29 16:00	Y				N	GnLaX7+XyU6UJnWj/cvi7g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:50		
+%R	89382	106319	4680	N			10595			30	30	3	0	3	0	0	0		0.00	5000.00	0.00	0.00	5000.00			2014-02-20 08:00	2014-02-22 10:00	2014-02-20 08:00	2014-02-22 10:00	2015-01-28 14:00	2015-01-29 16:00	Y				N	D+6iaBfb/E24zjtxmCMIvg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:50		
+%R	89383	106320	4680	N			10595			70	70	7	0	7	0	0	0		0.00	10000.00	0.00	0.00	10000.00			2014-02-16 10:00	2014-02-17 12:00	2014-02-16 10:00	2014-02-17 12:00	2014-03-04 08:00	2014-03-05 10:00	Y				N	/+WrRbQl9keDojeYMkp44g	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:51		
+%R	89384	106320	4680	N			10596			3	3	0.04285714	0	0.04285714	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-02-16 10:00	2014-02-25 16:00	2014-02-16 10:00	2014-02-25 16:00	2014-02-23 12:00	2014-03-05 10:00	Y				N	C42Ea8KGwUiPoIlfYDn8Ig	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:51		
+%R	89385	106321	4680	N			10596			3	3	0.1	0	0.1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-03-06 12:00	2014-03-11 10:00	2014-03-06 12:00	2014-03-11 10:00	2015-01-31 08:00	2015-02-03 14:00	Y				N	8dCAOhXYlkupOBWf39ZOOw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:52		
+%R	89386	106321	4680	N			10595			30	30	3	0	3	0	0	0		0.00	5000.00	0.00	0.00	5000.00			2014-03-06 12:00	2014-03-08 14:00	2014-03-06 12:00	2014-03-08 14:00	2015-02-02 12:00	2015-02-03 14:00	Y				N	4WHQKI27c0uH2Ayi39SWdA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:52		
+%R	89387	106322	4680	N			10595			70	70	7	0	7	0	0	0		0.00	10000.00	0.00	0.00	10000.00			2014-03-11 10:00	2014-03-12 12:00	2014-03-11 10:00	2014-03-12 12:00	2014-04-02 08:00	2014-04-03 10:00	Y				N	zE9svUpm8EelPUAVxgaDeQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:53		
+%R	89388	106322	4680	N			10596			3	3	0.04285714	0	0.04285714	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-03-11 10:00	2014-03-20 16:00	2014-03-11 10:00	2014-03-20 16:00	2014-03-24 12:00	2014-04-03 10:00	Y				N	U5Ax6ELBbEmYVQATJUiBmA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:53		
+%R	89389	106323	4680	N			10596			3	3	0.1	0	0.1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-04-05 12:00	2014-04-09 10:00	2014-04-05 12:00	2014-04-09 10:00	2015-02-03 14:00	2015-02-08 12:00	Y				N	sRhj9+Hp70qcB3vKkVxyAQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:54		
+%R	89390	106323	4680	N			10595			30	30	3	0	3	0	0	0		0.00	5000.00	0.00	0.00	5000.00			2014-04-05 12:00	2014-04-06 14:00	2014-04-05 12:00	2014-04-06 14:00	2015-02-07 10:00	2015-02-08 12:00	Y				N	ZL2RW/adoEqqEl0/ZHflAg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:54		
+%R	89391	106324	4680	N			10595			70	70	7	0	7	0	0	0		0.00	10000.00	0.00	0.00	10000.00			2014-04-03 10:00	2014-04-05 12:00	2014-04-03 10:00	2014-04-05 12:00	2014-05-08 10:00	2014-05-10 12:00	Y				N	EIpVUumaN0OjQCTO9sdrXg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:54		
+%R	89392	106324	4680	N			10596			3	3	0.04285714	0	0.04285714	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-04-03 10:00	2014-04-13 16:00	2014-04-03 10:00	2014-04-13 16:00	2014-04-29 14:00	2014-05-10 12:00	Y				N	I0A4i7s67U22SCzz2hbVQg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:55		
+%R	89393	106325	4680	N			10596			3	3	0.1	0	0.1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-04-28 12:00	2014-05-03 10:00	2014-04-28 12:00	2014-05-03 10:00	2015-02-08 12:00	2015-02-12 10:00	Y				N	Rsotc4+EOE2SXsmTcEJx2g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:55		
+%R	89394	106325	4680	N			10595			30	30	3	0	3	0	0	0		0.00	5000.00	0.00	0.00	5000.00			2014-04-28 12:00	2014-04-29 14:00	2014-04-28 12:00	2014-04-29 14:00	2015-02-11 08:00	2015-02-12 10:00	Y				N	PASnvjSt2UqsnbwkZ2aoog	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:55		
+%R	89395	106326	4680	N			10595			70	70	7	0	7	0	0	0		0.00	10000.00	0.00	0.00	10000.00			2014-04-28 12:00	2014-04-29 14:00	2014-04-28 12:00	2014-04-29 14:00	2014-06-15 14:00	2014-06-16 16:00	Y				N	dS03KXg1bUSMy5w72I9dsg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:56		
+%R	89396	106326	4680	N			10596			3	3	0.04285714	0	0.04285714	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-04-28 12:00	2014-05-08 10:00	2014-04-28 12:00	2014-05-08 10:00	2014-06-07 10:00	2014-06-16 16:00	Y				N	kpjIITFL80ezim64goQeig	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:56		
+%R	89397	106327	4680	N			10596			3	3	0.1	0	0.1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-05-25 08:00	2014-05-28 14:00	2014-05-25 08:00	2014-05-28 14:00	2015-02-12 10:00	2015-02-16 16:00	Y				N	sQ9vgttC5EuNwA7a6B1vGg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 21:57		
+%R	89398	106327	4680	N			10595			30	30	3	0	3	0	0	0		0.00	5000.00	0.00	0.00	5000.00			2014-05-25 08:00	2014-05-26 10:00	2014-05-25 08:00	2014-05-26 10:00	2015-02-15 14:00	2015-02-16 16:00	Y				N	YFImuvz7IE+RDiZzPn/VMg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 21:57		
+%R	89400	106328	4680	N			10595			30	30	3	0	3	0	0	0		0.00	4000.00	0.00	0.00	4000.00			2014-05-08 10:00	2014-05-10 12:00	2014-05-08 10:00	2014-05-10 12:00	2014-07-19 12:00	2014-07-20 14:00	Y				N	VeTbwsp/EU23wHnAK00mWQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:00		
+%R	89401	106328	4680	N			10596			3	3	0.1	0	0.1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-05-08 10:00	2014-05-12 16:00	2014-05-08 10:00	2014-05-12 16:00	2014-07-16 08:00	2014-07-20 14:00	Y				N	cQBlvanXJES9tsEl0HTvlw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:00		
+%R	89402	106329	4680	N			10596			3	3	0.15	0	0.15	0	0	0		0.00	750.00	0.00	0.00	750.00			2014-05-28 14:00	2014-06-01 10:00	2014-05-28 14:00	2014-06-01 10:00	2015-02-17 08:00	2015-02-19 12:00	Y				N	D2J3INXN2E6BjB1puOyBWQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:03		
+%R	89403	106329	4680	N			10595			20	20	2	0	2	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-05-28 14:00	2014-05-29 16:00	2014-05-28 14:00	2014-05-29 16:00	2015-02-18 10:00	2015-02-19 12:00	Y				N	CaTlHX3V+kCq+IyU5wzFtA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:03		
+%R	89404	106330	4680	N			10597			30	30	3	0	3	0	0	0	0	0.00	2500.00	0.00	0.00	2500.00			2014-02-23 12:00	2014-02-24 14:00	2014-02-23 12:00	2014-02-24 14:00	2014-05-19 08:00	2014-05-20 10:00	Y				N	WBpiYfSIwkaPGB1zN28O4w	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:07		
+%R	89405	106330	4680	N			10600			100	100	1	0	1	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-02-23 12:00	2014-03-09 16:00	2014-02-23 12:00	2014-03-09 16:00	2014-05-05 14:00	2014-05-20 10:00	Y				N	qv+vvnIqr0Ch5ExMyLuodQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:07		
+%R	89406	106331	4680	N			10600			50	50	1	0	1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-06-01 10:00	2014-06-08 12:00	Y				N	9rcoHnvyokm5kvGoPquK6Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:12		
+%R	89407	106331	4680	N			10598			30	30	3	0	3	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-03-05 10:00	2014-03-06 12:00	2014-03-05 10:00	2014-03-06 12:00	2014-06-07 10:00	2014-06-08 12:00	Y				N	I3dAjpGslkSWMA6yC8xBjA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:12		
+%R	89408	106332	4680	Y			10599			70	70	2.33333333	0	2.33333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-08 12:00	2014-06-12 10:00	2014-06-08 12:00	2014-06-12 10:00	2014-11-13 14:00	2014-11-18 12:00	Y				N	HS/Jh1YeakaNW/V9uuxvNQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:13		
+%R	89409	106332	4680	N			10600			7	7	0.1	0	0.1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-06-08 12:00	2014-06-18 10:00	2014-06-08 12:00	2014-06-18 10:00	2014-11-08 14:00	2014-11-18 12:00	Y				N	Sh3FharMmk6Fzh+6Q9pnqw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:13		
+%R	89410	106333	4680	N			10600			50	50	0.5	0	0.5	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-03-16 08:00	2014-03-30 12:00	2014-03-16 08:00	2014-03-30 12:00	2014-05-20 10:00	2014-06-03 14:00	Y				N	Btthm37GSEKxNAtmJZehbA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:14		
+%R	89411	106333	4680	N			10597			100	100	10	0	10	0	0	0	0	0.00	2500.00	0.00	0.00	2500.00			2014-03-16 08:00	2014-03-17 10:00	2014-03-16 08:00	2014-03-17 10:00	2014-06-02 12:00	2014-06-03 14:00	Y				N	Zby8L9tCeU6rhlUZu8hREw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:14		
+%R	89412	106334	4680	N			10598			1	1	0.1	0	0.1	0	0	0		0.00	4000.00	0.00	0.00	4000.00			2014-04-03 10:00	2014-04-05 12:00	2014-04-03 10:00	2014-04-05 12:00	2014-06-14 12:00	2014-06-15 14:00	Y				N	VQlVZNI8VkuIlb+dV4Irsw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:16		
+%R	89413	106334	4680	N			10600			50	50	1	0	1	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-04-03 10:00	2014-04-10 12:00	2014-04-03 10:00	2014-04-10 12:00	2014-06-08 12:00	2014-06-15 14:00	Y				N	lJYGpjBc70WiQMdKAJKpRg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:16		
+%R	89414	106335	4680	N			10600			50	50	0.5	0	0.5	0	0	0		0.00	2500.00	0.00	0.00	2500.00			2014-07-30 12:00	2014-08-13 16:00	2014-07-30 12:00	2014-08-13 16:00	2014-11-18 12:00	2014-12-02 16:00	Y				N	MM4zLMayIk67DL2xkltSjg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:17		
+%R	89415	106335	4680	Y			10599			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-30 12:00	2014-07-31 14:00	2014-07-30 12:00	2014-07-31 14:00	2014-12-01 14:00	2014-12-02 16:00	Y				N	M6qO3C1X3k2+IkFRevAZYg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:17		
+%R	89416	106336	4680	N			10597			1	1	0.1	0	0.1	0	0	0	0	0.00	3000.00	0.00	0.00	3000.00			2014-04-05 12:00	2014-04-06 14:00	2014-04-05 12:00	2014-04-06 14:00	2014-06-17 08:00	2014-06-18 10:00	Y				N	yNxbMYomOEWfiOVbP0dKug	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:19		
+%R	89417	106336	4680	N			10600			55	55	0.55	0	0.55	0	0	0		0.00	2500.00	0.00	0.00	2500.00			2014-04-05 12:00	2014-04-19 16:00	2014-04-05 12:00	2014-04-19 16:00	2014-06-03 14:00	2014-06-18 10:00	Y				N	dMPtXDCk2kaYSqxA7WtfZw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:19		
+%R	89418	106337	4680	N			10600			55	55	1.1	0	1.1	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-05-10 12:00	2014-05-17 14:00	2014-05-10 12:00	2014-05-17 14:00	2014-06-26 14:00	2014-07-03 16:00	Y				N	3n+VmGC/m0WTduO9cPthRg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:20		
+%R	89419	106337	4680	N			10598			1	1	0.1	0	0.1	0	0	0		0.00	6000.00	0.00	0.00	6000.00			2014-05-10 12:00	2014-05-11 14:00	2014-05-10 12:00	2014-05-11 14:00	2014-07-02 14:00	2014-07-03 16:00	Y				N	mB3OqOqUt0CyAttO8X0qtg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:20		
+%R	89420	106338	4680	Y			10599			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-15 12:00	2014-09-16 14:00	2014-09-15 12:00	2014-09-16 14:00	2014-12-16 10:00	2014-12-17 12:00	Y				N	HVYq0lnO20CULeDezRkPqg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:21		
+%R	89421	106338	4680	N			10600			55	55	0.55	0	0.55	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-09-15 12:00	2014-09-29 16:00	2014-09-15 12:00	2014-09-29 16:00	2014-12-03 08:00	2014-12-17 12:00	Y				N	ok2uuXO1NE6LxZJvTyPx0A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:21		
+%R	89422	106339	4680	N			10600			60	60	0.6	0	0.6	0	0	0		0.00	2500.00	0.00	0.00	2500.00			2014-04-26 08:00	2014-05-10 12:00	2014-04-26 08:00	2014-05-10 12:00	2014-06-18 10:00	2014-07-02 14:00	Y				N	n3eco6DYqEmrUXquBA6imA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:23		
+%R	89423	106339	4680	N			10597			1	1	0.1	0	0.1	0	0	0	0	0.00	3000.00	0.00	0.00	3000.00			2014-04-26 08:00	2014-04-27 10:00	2014-04-26 08:00	2014-04-27 10:00	2014-07-01 12:00	2014-07-02 14:00	Y				N	QXSCuizXCkOY70ZkXipzYw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:23		
+%R	89424	106340	4680	N			10598			1	1	0.1	0	0.1	0	0	0		0.00	6500.00	0.00	0.00	6500.00			2014-06-17 08:00	2014-06-18 10:00	2014-06-17 08:00	2014-06-18 10:00	2014-08-04 10:00	2014-08-05 12:00	Y				N	9b3kQXhvX06Wx6GOpcfalQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:24		
+%R	89425	106340	4680	N			10600			60	60	1.2	0	1.2	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-06-17 08:00	2014-06-24 10:00	2014-06-17 08:00	2014-06-24 10:00	2014-07-29 10:00	2014-08-05 12:00	Y				N	mU8mAfLcJkegfDeEDfa1YA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:24		
+%R	89426	106341	4680	N			10600			60	60	0.6	0	0.6	0	0	0		0.00	2500.00	0.00	0.00	2500.00			2014-10-18 08:00	2014-11-01 12:00	2014-10-18 08:00	2014-11-01 12:00	2014-12-17 12:00	2014-12-31 16:00	Y				N	KmTLJxX7DEyt/we4nz1TcA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:25		
+%R	89427	106341	4680	Y			10599			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-18 08:00	2014-10-19 10:00	2014-10-18 08:00	2014-10-19 10:00	2014-12-30 14:00	2014-12-31 16:00	Y				N	FbsWZIDHOE20mR6xefYqBg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:25		
+%R	89428	106342	4680	N			10597			1	1	0.1	0	0.1	0	0	0	0	0.00	3500.00	0.00	0.00	3500.00			2014-05-19 08:00	2014-05-20 10:00	2014-05-19 08:00	2014-05-20 10:00	2014-07-16 08:00	2014-07-17 10:00	Y				N	jZvgTRp9JkKtIPaajAqApw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:26		
+%R	89429	106342	4680	N			10600			60	60	0.6	0	0.6	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-05-19 08:00	2014-06-02 12:00	2014-05-19 08:00	2014-06-02 12:00	2014-07-02 14:00	2014-07-17 10:00	Y				N	p6WV1t+4Ek68iLg3STdv1A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:26		
+%R	89430	106343	4680	N			10600			60	60	1.2	0	1.2	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-07-20 14:00	2014-07-27 16:00	2014-07-20 14:00	2014-07-27 16:00	2014-08-20 08:00	2014-08-27 10:00	Y				N	5AvCGSQdlE2Dl+HLpHi1Wg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:27		
+%R	89431	106344	4680	N			10600			60	60	0.6	0	0.6	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-12-01 14:00	2014-12-16 10:00	2014-12-01 14:00	2014-12-16 10:00	2015-01-01 08:00	2015-01-15 12:00	Y				N	nRLMwMkjw0CGu1qamoFQaw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:27		
+%R	89432	106343	4680	N			10598			1	1	0.1	0	0.1	0	0	0		0.00	7000.00	0.00	0.00	7000.00			2014-07-20 14:00	2014-07-21 16:00	2014-07-20 14:00	2014-07-21 16:00	2014-08-26 08:00	2014-08-27 10:00	Y				N	jQHXdTvBfEyaESgJAhPQbg	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:27		
+%R	89433	106344	4680	Y			10599			1	1	0.01	0	0.01	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-12-01 14:00	2014-12-16 10:00	2014-12-01 14:00	2014-12-16 10:00	2015-01-01 08:00	2015-01-15 12:00	Y				N	qITPFm/CM0uLWMGQR8kxaQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:27		
+%R	89434	106345	4680	N			10600			20	20	0.2	0	0.2	0	0	0		0.00	1000.00	0.00	0.00	1000.00			2014-06-02 12:00	2014-06-16 16:00	2014-06-02 12:00	2014-06-16 16:00	2014-07-17 10:00	2014-07-31 14:00	Y				N	ooF4qx/sOEOFFDJG0PWzGw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:30		
+%R	89435	106346	4680	N			10600			20	20	0.4	0	0.4	0	0	0		0.00	1250.00	0.00	0.00	1250.00			2014-07-31 14:00	2014-08-07 16:00	2014-07-31 14:00	2014-08-07 16:00	2014-09-13 08:00	2014-09-20 10:00	Y				N	KdN/F7q+O0KOwtzJYg1LlA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:30		
+%R	89436	106347	4680	N			10600			20	20	0.28571429	0	0.28571429	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-12-16 10:00	2014-12-25 16:00	2014-12-16 10:00	2014-12-25 16:00	2015-01-15 12:00	2015-01-26 10:00	Y				N	wpW8cS8YYkWS4pEG9LhHwA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:30		
+%R	89437	106345	4680	N			10597			1	1	0.1	0	0.1	0	0	0	0	0.00	1250.00	0.00	0.00	1250.00			2014-06-02 12:00	2014-06-03 14:00	2014-06-02 12:00	2014-06-03 14:00	2014-07-30 12:00	2014-07-31 14:00	Y				N	V/2VqQ088UazKuVL+bT3mA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:30		
+%R	89438	106346	4680	N			10598			1	1	0.1	0	0.1	0	0	0		0.00	2500.00	0.00	0.00	2500.00			2014-07-31 14:00	2014-08-02 16:00	2014-07-31 14:00	2014-08-02 16:00	2014-09-18 08:00	2014-09-20 10:00	Y				N	u3FfHhc7g0eDmKDSpCuwhw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:30		
+%R	89439	106347	4680	Y			10599			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-12-16 10:00	2014-12-17 12:00	2014-12-16 10:00	2014-12-17 12:00	2015-01-25 08:00	2015-01-26 10:00	Y				N	ur48UZ0rlEOI/8I5qbteRw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:30		
+%R	89440	106348	4680	N			10600			1	1	0.01	0	0.01	0	0	0		0.00	3000.00	0.00	0.00	3000.00			2014-06-17 08:00	2014-07-01 12:00	2014-06-17 08:00	2014-07-01 12:00	2014-07-31 14:00	2014-08-16 10:00	Y				N	GWrxshkzgUair8kyj5hB1A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:33		
+%R	89441	106349	4680	N			10600			1	1	0.02	0	0.02	0	0	0		0.00	1000.00	0.00	0.00	1000.00			2014-08-26 08:00	2014-09-02 10:00	2014-08-26 08:00	2014-09-02 10:00	2014-11-06 12:00	2014-11-13 14:00	Y				N	pfXz8EHUS0yFJCvlSfv9MQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:33		
+%R	89442	106350	4680	N			10600			1	1	0.01	0	0.01	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	Y				N	bDBbKlmIUkqRNvB4e5Ot7w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:33		
+%R	89443	106348	4680	N			10597			1	1	0.1	0	0.1	0	0	0	0	0.00	2500.00	0.00	0.00	2500.00			2014-06-17 08:00	2014-06-18 10:00	2014-06-17 08:00	2014-06-18 10:00	2014-08-14 08:00	2014-08-16 10:00	Y				N	qOrnkhYR302MYz9Wcqyo1A	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:33		
+%R	89444	106349	4680	N			10598			1	1	0.1	0	0.1	0	0	0		0.00	1200.00	0.00	0.00	1200.00			2014-08-26 08:00	2014-08-27 10:00	2014-08-26 08:00	2014-08-27 10:00	2014-11-12 12:00	2014-11-13 14:00	Y				N	J1P6PEVTJ0iTX6GO86GiIA	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:33		
+%R	89445	106350	4680	Y			10599			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2015-01-26 10:00	2015-01-27 12:00	2015-01-26 10:00	2015-01-27 12:00	2015-02-08 12:00	2015-02-09 14:00	Y				N	11deBeHKZkyG/dhO0Noo2Q	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:33		
+%R	89446	106351	4680	N			10600			4	4	0.05714286	0	0.05714286	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-07-01 12:00	2014-07-12 10:00	2014-07-01 12:00	2014-07-12 10:00	2014-08-16 10:00	2014-08-25 16:00	Y				N	JPXyO6NGFU6MZF3RUCvQqg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:36		
+%R	89447	106352	4680	N			10600			4	4	0.08	0	0.08	0	0	0		0.00	2000.00	0.00	0.00	2000.00			2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	Y				N	eibX7k6SEUCvO/Mg8L1KPw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:36		
+%R	89448	106353	4680	N			10600			4	4	0.1	0	0.1	0	0	0		0.00	1500.00	0.00	0.00	1500.00			2014-11-22 08:00	2014-11-26 16:00	2014-11-22 08:00	2014-11-26 16:00	2015-02-03 14:00	2015-02-09 14:00	Y				N	oWLf7Dm9aE6LIdiVLj7JnQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-03 22:36		
+%R	89449	106351	4680	N			10597			1	1	0.1	0	0.1	0	0	0	0	0.00	2000.00	0.00	0.00	2000.00			2014-07-01 12:00	2014-07-02 14:00	2014-07-01 12:00	2014-07-02 14:00	2014-08-24 14:00	2014-08-25 16:00	Y				N	NfcP8YHUfE+NnmQ0iT35KQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:37		
+%R	89450	106352	4680	N			10598			1	1	0.1	0	0.1	0	0	0		0.00	5000.00	0.00	0.00	5000.00			2014-11-13 14:00	2014-11-15 16:00	2014-11-13 14:00	2014-11-15 16:00	2014-11-19 14:00	2014-11-20 16:00	Y				N	C4Armf7pbU640i+6tuZvgQ	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:37		
+%R	89451	106353	4680	Y			10599			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-22 08:00	2014-11-23 10:00	2014-11-22 08:00	2014-11-23 10:00	2015-02-08 12:00	2015-02-09 14:00	Y				N	4gSreu+5oEW6Ax1rSq1CLw	COST_PER_QTY	0.00	0		RT_Mat	ST_Rsrc	admin	2013-09-03 22:37		
+%R	89467	106224	4680	Y			10602			35	35	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-10-10 14:00	2013-10-21 12:00	2013-10-10 14:00	2013-10-21 12:00	2013-10-10 14:00	2013-10-21 12:00	Y				N	+IWfEMYis0ytLmb6Z4LRpQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:03		
+%R	89468	106224	4680	Y			10603			12	12	0.17142857	0	0.17142857	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-10-10 14:00	2013-10-21 12:00	2013-10-10 14:00	2013-10-21 12:00	2013-10-10 14:00	2013-10-21 12:00	Y				N	Z1DbBtWjXkq5HTFLS9/p8Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:04		
+%R	89469	106225	4680	Y			10602			61	61	0.87142857	0	0.87142857	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-10-21 12:00	2013-10-31 10:00	2013-10-21 12:00	2013-10-31 10:00	2013-10-28 14:00	2013-11-07 12:00	Y				N	E3rd6dttZUK4dVTU0pdfwQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:04		
+%R	89470	106225	4680	Y			10604			76	76	1.52	0	1.52	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-10-21 12:00	2013-10-28 14:00	2013-10-21 12:00	2013-10-28 14:00	2013-10-31 10:00	2013-11-07 12:00	Y				N	Ftz7JFEGO0mKxi7NfynQnw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:05		
+%R	89472	106225	4680	Y			10603			46	46	0.38333333	0	0.38333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-10-21 12:00	2013-11-07 12:00	2013-10-21 12:00	2013-11-07 12:00	2013-10-21 12:00	2013-11-07 12:00	Y				N	FhOE+/ANH0WNw6okwQwgJQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:07		
+%R	89473	106226	4680	Y			10602			42	42	1.05	30	1.05	0	0	30		0.00	0.00	0.00	0.00	0.00			2013-11-12 10:00	2013-11-18 10:00	2013-11-12 10:00	2013-11-18 10:00	2013-11-12 10:00	2013-11-18 10:00	Y				N	+MT7VhrPDEuooRSTMFD4sQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:10		
+%R	89474	106225	4680	Y			10603			46	46	0.575	0	0.575	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-10-21 12:00	2013-11-02 12:00	2013-10-21 12:00	2013-11-02 12:00	2013-10-27 12:00	2013-11-07 12:00	Y				N	TSPn9EOc90iXaMo//6tmBw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:11		
+%R	89475	106226	4680	Y			10603			14	14	0.35	30	0.35	0	0	30		0.00	0.00	0.00	0.00	0.00			2013-11-12 10:00	2013-11-18 10:00	2013-11-12 10:00	2013-11-18 10:00	2013-11-12 10:00	2013-11-18 10:00	Y				N	bn5/BPi6IkemZ6t20Hx+Ww	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:11		
+%R	89476	106226	4680	Y			10604			28	28	0.93333333	0	0.93333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-11-07 12:00	2013-11-12 10:00	2013-11-07 12:00	2013-11-12 10:00	2013-11-13 12:00	2013-11-18 10:00	Y				N	B3Hl2D8sr0ykJOmEwQ8nHg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:12		
+%R	89477	106226	4680	Y			10603			9	9	0.3	0	0.3	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-11-07 12:00	2013-11-12 10:00	2013-11-07 12:00	2013-11-12 10:00	2013-11-13 12:00	2013-11-18 10:00	Y				N	gbIR9S6ZDkK/b/S0AbohmQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:18		
+%R	89478	106227	4680	Y			10602			2	2	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-05 08:00	2013-12-08 12:00	2013-12-05 08:00	2013-12-08 12:00	2013-12-05 08:00	2013-12-08 12:00	Y				N	ocFUZFYz7E6PZN4Je4JY7w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:19		
+%R	89479	106227	4680	Y			10603			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-05 08:00	2013-12-07 10:00	2013-12-05 08:00	2013-12-07 10:00	2013-12-07 10:00	2013-12-08 12:00	Y				N	n6Skh1vIVkOAhekN8QmO7A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:19		
+%R	89480	106227	4680	Y			10604			3	3	0.3	0	0.3	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-05 08:00	2013-12-07 10:00	2013-12-05 08:00	2013-12-07 10:00	2013-12-07 10:00	2013-12-08 12:00	Y				N	awatOhWIwE+0wlVwYyehnw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:20		
+%R	89481	106227	4680	Y			10603			1	1	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-05 08:00	2013-12-07 10:00	2013-12-05 08:00	2013-12-07 10:00	2013-12-07 10:00	2013-12-08 12:00	Y				N	p6bC7dPijESzdJfIf2oLfA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:20		
+%R	89482	106230	4680	Y			10605			8	8	0.26666667	0	0.26666667	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	Y				N	j8mqaQt9Y0m4ZjtJ2Pv+fQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:22		
+%R	89483	106230	4680	Y			10603			4	4	0.13333333	0	0.13333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	2013-11-18 10:00	2013-11-21 16:00	Y				N	96sAsB8wk0avh1BHMtxU7w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:22		
+%R	89484	106228	4680	Y			10606			4	4	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-11-23 08:00	2013-11-25 12:00	2013-11-23 08:00	2013-11-25 12:00	2013-11-23 08:00	2013-11-25 12:00	Y				N	4VE4onwR40OuvecylbXxFw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:23		
+%R	89485	106229	4680	Y			10606			5	5	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	2013-11-25 12:00	2013-11-26 14:00	Y				N	AEBAH4AES0Oq+TfXcoX5qg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:24		
+%R	89486	106231	4680	Y			10602			16	16	0.32	20	0.32	0	0	20		0.00	0.00	0.00	0.00	0.00			2013-12-11 08:00	2013-12-18 10:00	2013-12-11 08:00	2013-12-18 10:00	2013-12-11 08:00	2013-12-18 10:00	Y				N	yTHK1C38UkO60tKctGc0Gw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:25		
+%R	89487	106231	4680	Y			10603			5	5	0.1	20	0.1	0	0	20		0.00	0.00	0.00	0.00	0.00			2013-12-11 08:00	2013-12-18 10:00	2013-12-11 08:00	2013-12-18 10:00	2013-12-11 08:00	2013-12-18 10:00	Y				N	I3Cp+GWiRUqmRi3dUkqZ8g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:25		
+%R	89488	106231	4680	Y			10604			11	11	0.55	0	0.55	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-08 12:00	2013-12-10 16:00	2013-12-08 12:00	2013-12-10 16:00	2013-12-15 14:00	2013-12-18 10:00	Y				N	zE8aEp6OI0mvHzgWgxZuug	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:25		
+%R	89489	106231	4680	Y			10603			4	4	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-08 12:00	2013-12-10 16:00	2013-12-08 12:00	2013-12-10 16:00	2013-12-15 14:00	2013-12-18 10:00	Y				N	xQxcmDUDgEGs8JQgh1yy9Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:26		
+%R	89490	106232	4680	Y			10602			26	26	0.37142857	0	0.37142857	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-18 10:00	2013-12-29 16:00	2013-12-18 10:00	2013-12-29 16:00	2013-12-23 08:00	2014-01-02 14:00	Y				N	4sjMisC0kEedrYtsyoGDQQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:27		
+%R	89491	106232	4680	Y			10603			9	9	0.12857143	0	0.12857143	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-18 10:00	2013-12-29 16:00	2013-12-18 10:00	2013-12-29 16:00	2013-12-23 08:00	2014-01-02 14:00	Y				N	k2hF3VT0yESLijFXPnzf1Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:28		
+%R	89492	106232	4680	Y			10602			6	6	0.3	80	0.3	0	0	80		0.00	0.00	0.00	0.00	0.00			2013-12-31 10:00	2014-01-02 14:00	2013-12-31 10:00	2014-01-02 14:00	2013-12-31 10:00	2014-01-02 14:00	Y				N	UHhF+dY8GkOLC5Bz2pMFFQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:28		
+%R	89493	106232	4680	Y			10603			2	2	0.1	80	0.1	0	0	80		0.00	0.00	0.00	0.00	0.00			2013-12-31 10:00	2014-01-02 14:00	2013-12-31 10:00	2014-01-02 14:00	2013-12-31 10:00	2014-01-02 14:00	Y				N	MLjRWGlMEkycIMuAEawjWQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:28		
+%R	89494	106232	4680	Y			10604			27	27	0.3375	0	0.3375	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-18 10:00	2013-12-31 10:00	2013-12-18 10:00	2013-12-31 10:00	2013-12-21 14:00	2014-01-02 14:00	Y				N	hn3Io7DdyUOTGwwYaYlbIw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:29		
+%R	89495	106232	4680	Y			10603			9	9	0.1125	0	0.1125	0	0	0		0.00	0.00	0.00	0.00	0.00			2013-12-18 10:00	2013-12-31 10:00	2013-12-18 10:00	2013-12-31 10:00	2013-12-21 14:00	2014-01-02 14:00	Y				N	qWbCLVLcV0WCIbOVEz0e4A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:30		
+%R	89496	106233	4680	Y			10602			35	35	0.7	20	0.7	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	Y				N	IoQ5KIhblkCOzlta6W5bxA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:43		
+%R	89497	106233	4680	Y			10603			12	12	0.24	20	0.24	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	2014-01-06 10:00	2014-01-13 12:00	Y				N	do/znZlJx0q2WvX6WoZB9A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:43		
+%R	89498	106233	4680	Y			10604			24	24	0.8	0	0.8	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-02 14:00	2014-01-07 12:00	2014-01-02 14:00	2014-01-07 12:00	2014-01-08 14:00	2014-01-13 12:00	Y				N	rrRPm65WrEy+vvuImhRrkg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:43		
+%R	89499	106233	4680	Y			10603			8	8	0.26666667	0	0.26666667	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-02 14:00	2014-01-07 12:00	2014-01-02 14:00	2014-01-07 12:00	2014-01-08 14:00	2014-01-13 12:00	Y				N	U3re7gwWfEuxiuT94wDAKg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:44		
+%R	89500	106234	4680	Y			10602			22	22	0.44	20	0.44	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-01-16 08:00	2014-01-23 10:00	2014-01-16 08:00	2014-01-23 10:00	2014-01-22 08:00	2014-01-29 10:00	Y				N	/wxWj7AnE0qiyl9hky2G4Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:45		
+%R	89501	106234	4680	Y			10603			7	7	0.14	20	0.14	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-01-16 08:00	2014-01-23 10:00	2014-01-16 08:00	2014-01-23 10:00	2014-01-22 08:00	2014-01-29 10:00	Y				N	E4hXxv2g90y3WqVLsPDRtQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:45		
+%R	89502	106234	4680	Y			10602			8	8	0.4	80	0.4	0	0	80		0.00	0.00	0.00	0.00	0.00			2014-01-25 12:00	2014-01-27 16:00	2014-01-25 12:00	2014-01-27 16:00	2014-01-26 14:00	2014-01-29 10:00	Y				N	JZZDF5vMb06v85tHcOA/IQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:46		
+%R	89503	106234	4680	Y			10603			3	3	0.15	80	0.15	0	0	80		0.00	0.00	0.00	0.00	0.00			2014-01-25 12:00	2014-01-27 16:00	2014-01-25 12:00	2014-01-27 16:00	2014-01-26 14:00	2014-01-29 10:00	Y				N	H2rzAs+SH0uOfsbXQRBCcA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:46		
+%R	89504	106234	4680	Y			10604			25	25	0.41666667	50	0.41666667	0	0	50		0.00	0.00	0.00	0.00	0.00			2014-01-20 14:00	2014-01-29 10:00	2014-01-20 14:00	2014-01-29 10:00	2014-01-20 14:00	2014-01-29 10:00	Y				N	lXdzFvzS1EmqWsQJAmhjKA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:46		
+%R	89505	106234	4680	Y			10603			8	8	0.13333333	50	0.13333333	0	0	50		0.00	0.00	0.00	0.00	0.00			2014-01-20 14:00	2014-01-29 10:00	2014-01-20 14:00	2014-01-29 10:00	2014-01-20 14:00	2014-01-29 10:00	Y				N	vzMJuy5WsEmYNIQjO05khQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:47		
+%R	89506	106235	4680	Y			10602			25	25	0.5	20	0.5	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-02-01 14:00	2014-02-08 16:00	2014-02-01 14:00	2014-02-08 16:00	2014-02-15 08:00	2014-02-22 10:00	Y				N	1vvH95SPD06C9CP2GDwnJA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:47		
+%R	89507	106235	4680	Y			10603			8	8	0.16	20	0.16	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-02-01 14:00	2014-02-08 16:00	2014-02-01 14:00	2014-02-08 16:00	2014-02-15 08:00	2014-02-22 10:00	Y				N	YHSyDU1/dECXBbjVqbdh7w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:47		
+%R	89508	106235	4680	Y			10604			17	17	0.425	0	0.425	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-29 10:00	2014-02-04 10:00	2014-01-29 10:00	2014-02-04 10:00	2014-02-16 10:00	2014-02-22 10:00	Y				N	slIoOSlskkqO7hswoHNdGA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:48		
+%R	89509	106235	4680	Y			10603			6	6	0.15	0	0.15	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-29 10:00	2014-02-04 10:00	2014-01-29 10:00	2014-02-04 10:00	2014-02-16 10:00	2014-02-22 10:00	Y				N	K0ixVONAW0m+PbRLSykmiA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:48		
+%R	89510	106236	4680	Y			10602			22	22	0.44	0	0.44	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-09 08:00	2014-02-16 10:00	2014-02-09 08:00	2014-02-16 10:00	2014-03-01 12:00	2014-03-08 14:00	Y				N	FNey9bfXd0yTMx6mAP+Ojg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:50		
+%R	89511	106236	4680	Y			10603			7	7	0.14	0	0.14	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-09 08:00	2014-02-16 10:00	2014-02-09 08:00	2014-02-16 10:00	2014-03-01 12:00	2014-03-08 14:00	Y				N	vOc0GOUI5EmHP0qOfUlKqg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:50		
+%R	89512	106236	4680	Y			10602			9	9	0.45	80	0.45	0	0	80		0.00	0.00	0.00	0.00	0.00			2014-02-20 08:00	2014-02-23 12:00	2014-02-20 08:00	2014-02-23 12:00	2014-03-05 10:00	2014-03-08 14:00	Y				N	YAJ/I3wyE0i5+BQyHISf5w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:50		
+%R	89513	106236	4680	Y			10603			2	2	0.1	80	0.1	0	0	80		0.00	0.00	0.00	0.00	0.00			2014-02-20 08:00	2014-02-23 12:00	2014-02-20 08:00	2014-02-23 12:00	2014-03-05 10:00	2014-03-08 14:00	Y				N	ktljJGfNnEe2UV1HV6/UHQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:50		
+%R	89514	106236	4680	Y			10604			26	26	0.65	50	0.65	0	0	50		0.00	0.00	0.00	0.00	0.00			2014-02-16 10:00	2014-02-22 10:00	2014-02-16 10:00	2014-02-22 10:00	2014-03-02 14:00	2014-03-08 14:00	Y				N	TnAdreov6kmlFWXLJa4+aw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:52		
+%R	89515	106236	4680	Y			10603			9	9	0.225	50	0.225	0	0	50		0.00	0.00	0.00	0.00	0.00			2014-02-16 10:00	2014-02-22 10:00	2014-02-16 10:00	2014-02-22 10:00	2014-03-02 14:00	2014-03-08 14:00	Y				N	u95TKf82xke8ks1mk6ON2A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:53		
+%R	89516	106237	4680	Y			10602			11	11	0.22	20	0.22	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-02-26 08:00	2014-03-05 10:00	2014-02-26 08:00	2014-03-05 10:00	2014-03-24 12:00	2014-03-31 14:00	Y				N	HEQcSGaWpUaPvebcAMiF/g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:53		
+%R	89517	106237	4680	Y			10603			4	4	0.08	20	0.08	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-02-26 08:00	2014-03-05 10:00	2014-02-26 08:00	2014-03-05 10:00	2014-03-24 12:00	2014-03-31 14:00	Y				N	TvvonzCLWEi4fNSoJQGKSQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:54		
+%R	89518	106237	4680	Y			10604			8	8	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-23 12:00	2014-03-01 12:00	2014-02-23 12:00	2014-03-01 12:00	2014-03-25 14:00	2014-03-31 14:00	Y				N	NT7Zoa80tEmh/72ii6Fa5A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:54		
+%R	89519	106237	4680	Y			10603			3	3	0.075	0	0.075	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-23 12:00	2014-03-01 12:00	2014-02-23 12:00	2014-03-01 12:00	2014-03-25 14:00	2014-03-31 14:00	Y				N	IPRTPcOVekKRNfbpf75ukg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:54		
+%R	89520	106238	4680	Y			10602			36	36	0.72	0	0.72	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-04-08 08:00	2014-04-15 10:00	Y				N	T6vNrgyZX0+H10g9qmC4lw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:55		
+%R	89521	106238	4680	Y			10603			112	112	2.24	0	2.24	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-04-08 08:00	2014-04-15 10:00	Y				N	8x3MJK/QAUGlTDXYPZ2EEA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:55		
+%R	89522	106238	4680	Y			10604			30	30	0.6	30	0.6	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-03-10 08:00	2014-03-17 10:00	2014-03-10 08:00	2014-03-17 10:00	2014-04-08 08:00	2014-04-15 10:00	Y				N	dtKFVmSO0UCcjYRjK5h4aQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:55		
+%R	89523	106238	4680	Y			10603			10	10	0.2	30	0.2	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-03-10 08:00	2014-03-17 10:00	2014-03-10 08:00	2014-03-17 10:00	2014-04-08 08:00	2014-04-15 10:00	Y				N	mKnhaPVCWkKTeCSFqH4CoA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 15:56		
+%R	89524	106239	4680	Y			10602			10	10	0.25	30	0.25	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-03-24 12:00	2014-03-30 12:00	2014-03-24 12:00	2014-03-30 12:00	2014-05-03 10:00	2014-05-08 10:00	Y				N	A6KUearUwUGf39+KU34xTA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:05		
+%R	89525	106239	4680	Y			10603			3	3	0.075	30	0.075	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-03-24 12:00	2014-03-30 12:00	2014-03-24 12:00	2014-03-30 12:00	2014-05-03 10:00	2014-05-08 10:00	Y				N	T8sfCZPWiUyGWY7btdY5pg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:06		
+%R	89526	106239	4680	Y			10604			7	7	0.175	0	0.175	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-19 14:00	2014-03-25 14:00	2014-03-19 14:00	2014-03-25 14:00	2014-05-03 10:00	2014-05-08 10:00	Y				N	B2sRD+quTUGZmlKqcaEMKA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:06		
+%R	89527	106239	4680	Y			10603			2	2	0.05	0	0.05	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-19 14:00	2014-03-25 14:00	2014-03-19 14:00	2014-03-25 14:00	2014-05-03 10:00	2014-05-08 10:00	Y				N	z8xYyQuM50CMZJOB2fwWrw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:06		
+%R	89529	106240	4680	N			10557			40	40	2	80	2	0	0	80		0.00	19500.00	0.00	0.00	19500.00			2014-04-10 12:00	2014-04-13 16:00	2014-04-10 12:00	2014-04-13 16:00	2014-05-20 10:00	2014-05-22 14:00	Y				N	YGp1UQ0DLU6jb5qXKowljw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:08		
+%R	89530	106240	4680	Y			10602			16	16	0.32	0	0.32	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-30 12:00	2014-04-06 14:00	2014-03-30 12:00	2014-04-06 14:00	2014-05-15 12:00	2014-05-22 14:00	Y				N	pbRKpHRoSki+v94i/gv3BQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:09		
+%R	89531	106240	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-30 12:00	2014-04-06 14:00	2014-03-30 12:00	2014-04-06 14:00	2014-05-15 12:00	2014-05-22 14:00	Y				N	V+2mso4KPkS15FEhEmeDDg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:09		
+%R	89532	106240	4680	Y			10602			8	8	0.4	80	0.4	0	0	80		0.00	0.00	0.00	0.00	0.00			2014-04-10 12:00	2014-04-13 16:00	2014-04-10 12:00	2014-04-13 16:00	2014-05-20 10:00	2014-05-22 14:00	Y				N	z3gcjdkyH0ayf+GH9/9rNw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:10		
+%R	89533	106240	4680	Y			10603			3	3	0.15	80	0.15	0	0	80		0.00	0.00	0.00	0.00	0.00			2014-04-10 12:00	2014-04-13 16:00	2014-04-10 12:00	2014-04-13 16:00	2014-05-20 10:00	2014-05-22 14:00	Y				N	eaVGxGAf3EWd2dRLeVuwTQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:10		
+%R	89534	106240	4680	Y			10604			26	26	0.43333333	20	0.43333333	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-04-02 08:00	2014-04-10 12:00	2014-04-02 08:00	2014-04-10 12:00	2014-05-14 10:00	2014-05-22 14:00	Y				N	ondAuGilAECpmsokOwz9cw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:10		
+%R	89535	106240	4680	Y			10603			9	9	0.15	20	0.15	0	0	20		0.00	0.00	0.00	0.00	0.00			2014-04-02 08:00	2014-04-10 12:00	2014-04-02 08:00	2014-04-10 12:00	2014-05-14 10:00	2014-05-22 14:00	Y				N	9iGRderV/06//TCky13Wvg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:10		
+%R	89536	106241	4680	Y			10602			2	2	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-14 08:00	2014-04-16 12:00	2014-04-14 08:00	2014-04-16 12:00	2014-06-24 10:00	2014-06-26 14:00	Y				N	njtTdjUJtEWII59OjbZtXA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:11		
+%R	89537	106241	4680	Y			10603			1	1	0.05	0	0.05	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-14 08:00	2014-04-16 12:00	2014-04-14 08:00	2014-04-16 12:00	2014-06-24 10:00	2014-06-26 14:00	Y				N	jQlgX64pjESODYrm7OsFTw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:11		
+%R	89538	106241	4680	Y			10602			1	1	0.05	30	0.05	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-04-17 14:00	2014-04-21 10:00	2014-04-17 14:00	2014-04-21 10:00	2014-06-24 10:00	2014-06-26 14:00	Y				N	iCzI3Pf3WEK2JAj5Na9izw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:11		
+%R	89539	106241	4680	Y			10603			1	1	0.05	30	0.05	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-04-17 14:00	2014-04-21 10:00	2014-04-17 14:00	2014-04-21 10:00	2014-06-24 10:00	2014-06-26 14:00	Y				N	cgcjcvKjBkiVXjRF//NmUQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:12		
+%R	89540	106241	4680	Y			10604			3	3	0.1	10	0.1	0	0	10		0.00	0.00	0.00	0.00	0.00			2014-04-15 10:00	2014-04-19 16:00	2014-04-15 10:00	2014-04-19 16:00	2014-06-23 08:00	2014-06-26 14:00	Y				N	QnvxuIyAKk6xmLPDqIke/w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:12		
+%R	89541	106241	4680	Y			10603			1	1	0.03333333	10	0.03333333	0	0	10		0.00	0.00	0.00	0.00	0.00			2014-04-15 10:00	2014-04-19 16:00	2014-04-15 10:00	2014-04-19 16:00	2014-06-23 08:00	2014-06-26 14:00	Y				N	+HNO6v0+oUOOgMMmy934wg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:13		
+%R	89542	106242	4680	Y			10602			2	2	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-21 10:00	2014-04-23 14:00	2014-04-21 10:00	2014-04-23 14:00	2014-07-01 12:00	2014-07-03 16:00	Y				N	zzoGMy5M4kKgLm8t3sWicQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:13		
+%R	89543	106242	4680	Y			10603			1	1	0.05	0	0.05	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-21 10:00	2014-04-23 14:00	2014-04-21 10:00	2014-04-23 14:00	2014-07-01 12:00	2014-07-03 16:00	Y				N	NZTgl2PHiUm/AdKIxsZXMw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:13		
+%R	89544	106242	4680	Y			10602			1	1	0.05	30	0.05	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-04-26 08:00	2014-04-28 12:00	2014-04-26 08:00	2014-04-28 12:00	2014-07-01 12:00	2014-07-03 16:00	Y				N	5asqqTIcFUis+CyMQKkHYw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:14		
+%R	89545	106242	4680	Y			10603			1	1	0.05	30	0.05	0	0	30		0.00	0.00	0.00	0.00	0.00			2014-04-26 08:00	2014-04-28 12:00	2014-04-26 08:00	2014-04-28 12:00	2014-07-01 12:00	2014-07-03 16:00	Y				N	BkPz5SvKG0a1o33WhYv7qw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:14		
+%R	89546	106242	4680	Y			10604			3	3	0.1	10	0.1	0	0	10		0.00	0.00	0.00	0.00	0.00			2014-04-22 12:00	2014-04-27 10:00	2014-04-22 12:00	2014-04-27 10:00	2014-06-30 10:00	2014-07-03 16:00	Y				N	PoaCZxhnvk667QGoEcTTRw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:14		
+%R	89547	106242	4680	Y			10603			1	1	0.03333333	10	0.03333333	0	0	10		0.00	0.00	0.00	0.00	0.00			2014-04-22 12:00	2014-04-27 10:00	2014-04-22 12:00	2014-04-27 10:00	2014-06-30 10:00	2014-07-03 16:00	Y				N	ZTKeYU2QnUOYYW5JwfJiCg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 16:14		
+%R	89549	106278	4680	Y			10603			2	2	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-12 14:00	2014-08-13 16:00	2014-08-12 14:00	2014-08-13 16:00	2015-01-13 08:00	2015-01-14 10:00	Y				N	z/c5AfX4Z0Gqy9inrTnVLw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:31		
+%R	89550	106243	4680	Y			10605			16	16	0.53333333	0	0.53333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	Y				N	tx6a4iuUhEuwfNYs+lEZ/A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:31		
+%R	89551	106243	4680	Y			10603			10	10	0.33333333	0	0.33333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	2014-01-29 10:00	2014-02-02 16:00	Y				N	VThpbpldCUGprKongeTRPw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:32		
+%R	89552	106248	4680	Y			10605			100	100	1.11111111	0	1.11111111	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-03 08:00	2014-02-16 10:00	2014-02-03 08:00	2014-02-16 10:00	2014-02-10 10:00	2014-02-23 12:00	Y				N	GdT7W+uSHU6x3rulxDaREQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:32		
+%R	89553	106248	4680	Y			10603			67	67	0.74444444	0	0.74444444	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-03 08:00	2014-02-16 10:00	2014-02-03 08:00	2014-02-16 10:00	2014-02-10 10:00	2014-02-23 12:00	Y				N	FK+nQGydOEibLihftS7Avg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:32		
+%R	89554	106254	4680	Y			10605			67	67	0.60909091	0	0.60909091	0	0	0		0.00	0.00	0.00	0.00	0.00	2014-02-23 12:00		2014-02-23 12:00	2014-03-11 10:00	2014-02-23 12:00	2014-03-11 10:00	2014-03-08 14:00	2014-03-24 12:00	Y				N	AJdhNyvyyUW8clRzTx+ggQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:33		
+%R	89555	106260	4680	Y			10605			104	104	1.04	0	1.04	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00	Y				N	auaYQ9lJDk2kDcuAoiIfkA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:33		
+%R	89556	106260	4680	Y			10603			70	70	0.7	0	0.7	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-19 14:00	2014-04-03 10:00	2014-03-19 14:00	2014-04-03 10:00	2014-04-15 10:00	2014-04-29 14:00	Y				N	ExDHC+y5f0uyEWBxqZzAlQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:34		
+%R	89557	106266	4680	Y			10605			118	118	1.18	0	1.18	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2014-05-22 14:00	2014-06-07 10:00	Y				N	Lmnzc/q3KUq5n+YsZLF3FQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:34		
+%R	89558	106266	4680	Y			10603			79	79	0.79	0	0.79	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2014-05-22 14:00	2014-06-07 10:00	Y				N	ON+gHDA3T0yyypdPyM9n8Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:34		
+%R	89559	106272	4680	Y			10605			16	16	0.8	0	0.8	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-28 12:00	2014-04-30 16:00	2014-04-28 12:00	2014-04-30 16:00	2014-07-05 08:00	2014-07-07 12:00	Y				N	oN4Hvi/7OE+pOgGJXvnvaw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:35		
+%R	89560	106272	4680	Y			10603			11	11	0.55	0	0.55	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-28 12:00	2014-04-30 16:00	2014-04-28 12:00	2014-04-30 16:00	2014-07-05 08:00	2014-07-07 12:00	Y				N	QeeQJDk2w0ilcbE6iz4Ueg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:35		
+%R	89561	106245	4680	Y			10607			82	82	0.58571429	0	0.58571429	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	Y				N	8ddGJ7Eudkmh5MPKtvMfrQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:36		
+%R	89562	106245	4680	Y			10603			28	28	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	2014-02-12 14:00	2014-03-05 10:00	Y				N	B0SEhZtSAUGGALuQ4fpXeQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:36		
+%R	89563	106250	4680	Y			10607			200	200	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	Y				N	/tq3/zNec0KwztTpvY5z6A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:42		
+%R	89564	106250	4680	Y			10603			200	200	1	0	1	0	0	0		0.00	48.00	0.00	0.00	48.00			2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	2014-03-05 10:00	2014-04-03 10:00	Y				N	3SA06UXpTE2B84CCqkovAg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:42		
+%R	89565	106256	4680	Y			10607			222	222	0.888	0	0.888	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	Y				N	RQMSROFv90iiYwzpO5oQgQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:43		
+%R	89566	106256	4680	Y			10603			74	74	0.296	0	0.296	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	2014-04-03 10:00	2014-05-10 12:00	Y				N	IHqjw1NPRk+A8LSFsjGI1Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:43		
+%R	89567	106262	4680	Y			10607			231	231	0.88846154	0	0.88846154	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	Y				N	Esy6PhdyuEqndSaWPWUI9g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:44		
+%R	89568	106262	4680	Y			10603			77	77	0.29615385	0	0.29615385	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	2014-05-10 12:00	2014-06-16 16:00	Y				N	W+K2wJ+v3EWRDVMMz3VSIA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:44		
+%R	89569	106268	4680	Y			10605			199	199	0.86521739	0	0.86521739	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	Y				N	QOJUP465okyAea42/R5/Nw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:44		
+%R	89570	106268	4680	Y			10603			67	67	0.29130435	0	0.29130435	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	2014-06-17 08:00	2014-07-20 14:00	Y				N	QB4SrxE+TECNE9lmUhE/Tw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:45		
+%R	89571	106274	4680	Y			10607			80	80	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	Y				N	KTcebH1100mmFYARgPNmpg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:45		
+%R	89572	106274	4680	Y			10603			80	80	1	0	1	0	0	0		0.00	20.00	0.00	0.00	20.00			2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	2014-07-20 14:00	2014-07-31 14:00	Y				N	Ile3K6FRZ0GN2bxrYpns/w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:45		
+%R	89573	106279	4680	Y			10607			142	142	0.83529412	0	0.83529412	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	Y				N	XZVWW38/w0aePreizCxsEw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:45		
+%R	89574	106279	4680	Y			10603			94	94	0.55294118	0	0.55294118	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	2014-07-31 14:00	2014-08-25 16:00	Y				N	qSZkyIzXG0GH+z7Zffrpsg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:46		
+%R	89575	106281	4680	Y			10607			1000	1000	1.81818182	0	1.81818182	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	Y				N	tLrq3Qkzhka2xDjGlHdtXQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:46		
+%R	89577	106281	4680	Y			10603			667	667	1.21272727	0	1.21272727	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	2014-08-26 08:00	2014-11-13 14:00	Y				N	SH/Q5hE39EuOrcXF/sjOdQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 18:47		
+%R	89578	106246	4680	Y			10608			12	12	0.24	0	0.24	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-12 14:00	2014-02-19 16:00	2014-02-12 14:00	2014-02-19 16:00	2014-12-07 14:00	2014-12-14 16:00	Y				N	3yb/YmC7MkeRtHqNaguqGA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:16		
+%R	89579	106246	4680	Y			10603			6	6	0.12	0	0.12	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-12 14:00	2014-02-19 16:00	2014-02-12 14:00	2014-02-19 16:00	2014-12-07 14:00	2014-12-14 16:00	Y				N	O2xT709Cxk2DlmZyeoyBZg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:17		
+%R	89580	106252	4680	Y			10608			34	34	0.34	0	0.34	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-20 08:00	2014-03-06 12:00	2014-02-20 08:00	2014-03-06 12:00	2014-12-15 08:00	2014-12-29 12:00	Y				N	GB/55ClIhEy9yP2ydbnxHg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:17		
+%R	89581	106252	4680	Y			10603			17	17	0.17	0	0.17	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-20 08:00	2014-03-06 12:00	2014-02-20 08:00	2014-03-06 12:00	2014-12-15 08:00	2014-12-29 12:00	Y				N	k2+087mggUSm4Ox2eVYP4Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:18		
+%R	89582	106258	4680	Y			10608			32	32	0.32	0	0.32	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-22 08:00	2014-04-05 12:00	2014-03-22 08:00	2014-04-05 12:00	2014-12-29 12:00	2015-01-12 16:00	Y				N	2iGzuFeg0USyjCK9PRLIgQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:22		
+%R	89583	106258	4680	Y			10603			16	16	0.16	0	0.16	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-22 08:00	2014-04-05 12:00	2014-03-22 08:00	2014-04-05 12:00	2014-12-29 12:00	2015-01-12 16:00	Y				N	XNIPNxGwakqTaK87o97EZA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:22		
+%R	89584	106264	4680	Y			10608			50	50	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2015-01-13 08:00	2015-01-27 12:00	Y				N	TcoLY4/MvEaQYj2NfGwxJw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:22		
+%R	89585	106264	4680	Y			10603			25	25	0.25	0	0.25	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-14 08:00	2014-04-28 12:00	2014-04-14 08:00	2014-04-28 12:00	2015-01-13 08:00	2015-01-27 12:00	Y				N	B0dlMvynxky54lCRfALdLQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:23		
+%R	89586	106270	4680	Y			10608			45	45	0.40909091	0	0.40909091	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-08 10:00	2014-05-24 16:00	2014-05-08 10:00	2014-05-24 16:00	2015-01-27 12:00	2015-02-12 10:00	Y				N	S4M9ZMwIGkWkL4vdmLp8uw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:23		
+%R	89587	106270	4680	Y			10603			23	23	0.20909091	0	0.20909091	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-08 10:00	2014-05-24 16:00	2014-05-08 10:00	2014-05-24 16:00	2015-01-27 12:00	2015-02-12 10:00	Y				N	++9+3ncn2Ee4UZ7QQ8gHdg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:23		
+%R	89588	106247	4680	Y			10610			60	60	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-16 12:00	2014-05-04 12:00	2014-04-16 12:00	2014-05-04 12:00	2014-06-21 14:00	2014-07-08 14:00	Y				N	XqiXT6omvU2go0zyByU4qw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:39		
+%R	89589	106247	4680	Y			10603			15	15	0.125	0	0.125	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-16 12:00	2014-05-04 12:00	2014-04-16 12:00	2014-05-04 12:00	2014-06-21 14:00	2014-07-08 14:00	Y				N	9ZGMolxe2EOAIYkJBP9tLA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:40		
+%R	89590	106253	4680	Y			10610			100	100	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-22 14:00	2014-06-21 14:00	2014-05-22 14:00	2014-06-21 14:00	2014-07-10 08:00	2014-08-07 16:00	Y				N	yQiv7FjY4ESewkb9LLu0Cg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:40		
+%R	89591	106253	4680	Y			10603			25	25	0.125	0	0.125	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-22 14:00	2014-06-21 14:00	2014-05-22 14:00	2014-06-21 14:00	2014-07-10 08:00	2014-08-07 16:00	Y				N	ZrGvvd1VGEu6rkTsDSKxiA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:40		
+%R	89592	106259	4680	Y			10610			144	144	0.96	0	0.96	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-30 10:00	2014-07-21 16:00	2014-06-30 10:00	2014-07-21 16:00	2014-08-11 12:00	2014-09-02 10:00	Y				N	kz3keGas+0qH52BPJuwqGg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:42		
+%R	89593	106259	4680	Y			10603			36	36	0.24	0	0.24	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-30 10:00	2014-07-21 16:00	2014-06-30 10:00	2014-07-21 16:00	2014-08-11 12:00	2014-09-02 10:00	Y				N	xHdZF++m70msG7ck02PPVw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:42		
+%R	89594	106265	4680	Y			10610			154	154	0.9625	0	0.9625	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-03 08:00	2014-08-25 16:00	2014-08-03 08:00	2014-08-25 16:00	2014-09-02 10:00	2014-09-25 10:00	Y				N	5liEbnYXMUy12ATTPPd2VQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:42		
+%R	89595	106265	4680	Y			10603			39	39	0.24375	0	0.24375	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-03 08:00	2014-08-25 16:00	2014-08-03 08:00	2014-08-25 16:00	2014-09-02 10:00	2014-09-25 10:00	Y				N	KRAyQiCSfEuQVQNPza4Hvw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:42		
+%R	89596	106271	4680	Y			10610			131	131	1.45555556	0	1.45555556	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-26 08:00	2014-09-08 10:00	2014-08-26 08:00	2014-09-08 10:00	2014-09-25 10:00	2014-10-08 12:00	Y				N	1e/4f+/2xkaXYbvlH7rjFw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:43		
+%R	89597	106271	4680	Y			10603			33	33	0.36666667	0	0.36666667	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-26 08:00	2014-09-08 10:00	2014-08-26 08:00	2014-09-08 10:00	2014-09-25 10:00	2014-10-08 12:00	Y				N	WDbIERjvLEin1R02WW6JTQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:43		
+%R	89598	106257	4680	Y			10609			6	6	0.15	0	0.15	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-17 14:00	2014-05-22 14:00	2014-05-17 14:00	2014-05-22 14:00	2014-07-05 08:00	2014-07-09 16:00	Y				N	KP9NCcqoSk+F75EqMp0pgQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:44		
+%R	89599	106257	4680	Y			10603			2	2	0.05	0	0.05	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-17 14:00	2014-05-22 14:00	2014-05-17 14:00	2014-05-22 14:00	2014-07-05 08:00	2014-07-09 16:00	Y				N	1IxYCjv9jEmCxL6GCD15vg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:44		
+%R	89600	106263	4680	Y			10609			7	7	0.175	0	0.175	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-24 10:00	2014-06-30 10:00	2014-06-24 10:00	2014-06-30 10:00	2014-08-05 12:00	2014-08-11 12:00	Y				N	AMLOPZ1nYkOUBwsnHPsV+g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:44		
+%R	89601	106263	4680	Y			10603			3	3	0.075	0	0.075	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-24 10:00	2014-06-30 10:00	2014-06-24 10:00	2014-06-30 10:00	2014-08-05 12:00	2014-08-11 12:00	Y				N	POtPSVVwiUiKqFOW2ctI1w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:44		
+%R	89602	106269	4680	Y			10609			6	6	0.15	0	0.15	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-28 08:00	2014-08-02 16:00	2014-07-28 08:00	2014-08-02 16:00	2014-08-27 10:00	2014-09-02 10:00	Y				N	qEuKzPDDLkCERmSRYn+B1A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:45		
+%R	89603	106269	4680	Y			10603			3	3	0.075	0	0.075	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-28 08:00	2014-08-02 16:00	2014-07-28 08:00	2014-08-02 16:00	2014-08-27 10:00	2014-09-02 10:00	Y				N	w+hbrlcpCkKY/H2HVsOfOw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:45		
+%R	89604	106275	4680	Y			10609			4	4	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-09 08:00	2014-08-13 16:00	2014-08-09 08:00	2014-08-13 16:00	2014-09-20 10:00	2014-09-25 10:00	Y				N	pV8plHyaEku7lXPQJLXwSA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:45		
+%R	89605	106275	4680	Y			10603			1	1	0.025	0	0.025	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-09 08:00	2014-08-13 16:00	2014-08-09 08:00	2014-08-13 16:00	2014-09-20 10:00	2014-09-25 10:00	Y				N	Ai36vx4qeUupV4TFt2LBvw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:45		
+%R	89606	106282	4680	Y			10608			12	12	0.24	0	0.24	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2015-02-12 10:00	2015-02-19 12:00	Y				N	2d5g3Cit3Uus6vjoW7IR9w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:46		
+%R	89607	106282	4680	Y			10603			6	6	0.12	0	0.12	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2015-02-12 10:00	2015-02-19 12:00	Y				N	xlUjOmnmx0mFneEXNN3C4g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:46		
+%R	89608	106276	4680	Y			10606			11	11	0.275	0	0.275	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-31 14:00	2014-08-06 14:00	2014-07-31 14:00	2014-08-06 14:00	2015-01-01 08:00	2015-01-06 16:00	Y				N	8ajR5BcmFE6aNZ4goQ71ag	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:46		
+%R	89609	106276	4680	Y			10603			4	4	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-31 14:00	2014-08-06 14:00	2014-07-31 14:00	2014-08-06 14:00	2015-01-01 08:00	2015-01-06 16:00	Y				N	B3Jxc6cXlkGm+17sgX6y0A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:46		
+%R	89610	106277	4680	Y			10606			11	11	0.275	0	0.275	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-06 14:00	2014-08-12 14:00	2014-08-06 14:00	2014-08-12 14:00	2015-01-07 08:00	2015-01-12 16:00	Y				N	rEZAoFwKekeZOm+vVjfmDg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:47		
+%R	89611	106277	4680	Y			10603			4	4	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-06 14:00	2014-08-12 14:00	2014-08-06 14:00	2014-08-12 14:00	2015-01-07 08:00	2015-01-12 16:00	Y				N	7r64WPJcxUSxup6I5RKJsw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:47		
+%R	89612	106284	4680	Y			10607			60	60	0.6	0	0.6	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-25 08:00	2014-06-08 12:00	2014-05-25 08:00	2014-06-08 12:00	2014-10-18 08:00	2014-11-01 12:00	Y				N	aWHlUU0DK0WWRjJgIud1bA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:47		
+%R	89613	106284	4680	Y			10603			15	15	0.15	0	0.15	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-25 08:00	2014-06-08 12:00	2014-05-25 08:00	2014-06-08 12:00	2014-10-18 08:00	2014-11-01 12:00	Y				N	lhj6zZUxo06KbVN3Ws+MCw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:47		
+%R	89614	106286	4680	Y			10614			32	32	0.32	0	0.32	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-03 14:00	2014-06-18 10:00	2014-06-03 14:00	2014-06-18 10:00	2014-08-09 08:00	2014-08-23 12:00	Y				N	S0N1fSW2JUOrIVFEPZi2nQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:54		
+%R	89615	106286	4680	Y			10603			16	16	0.16	0	0.16	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-03 14:00	2014-06-18 10:00	2014-06-03 14:00	2014-06-18 10:00	2014-08-09 08:00	2014-08-23 12:00	Y				N	yhSGKE4Wu0aTzGfFP3u9qQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:55		
+%R	89616	106287	4680	Y			10603			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-03 14:00	2014-06-14 12:00	2014-06-03 14:00	2014-06-14 12:00	2014-08-09 08:00	2014-08-18 14:00	Y				N	N8fIospwykCbMtfUvf32cQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:55		
+%R	89617	106290	4680	Y			10610			100	100	0.90909091	0	0.90909091	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-14 14:00	2014-07-30 12:00	2014-07-14 14:00	2014-07-30 12:00	2014-11-01 12:00	2014-11-17 10:00	Y				N	8RNVNKEZ+U65SCoiYUwWyQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:55		
+%R	89618	106290	4680	Y			10603			25	25	0.22727273	0	0.22727273	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-14 14:00	2014-07-30 12:00	2014-07-14 14:00	2014-07-30 12:00	2014-11-01 12:00	2014-11-17 10:00	Y				N	JENfljEpH06B5xGnfIFnnQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:56		
+%R	89619	106292	4680	Y			10614			27	27	0.38571429	0	0.38571429	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-09-08 10:00	2014-09-17 16:00	Y				N	xg6mFsW0ZUau1tXIEBobfw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:56		
+%R	89620	106292	4680	Y			10603			13	13	0.18571429	0	0.18571429	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-09-08 10:00	2014-09-17 16:00	Y				N	pZwEHlBNOEiqrEI3kITu2A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:56		
+%R	89621	106293	4680	Y			10603			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-22 08:00	2014-07-31 14:00	2014-07-22 08:00	2014-07-31 14:00	2014-09-08 10:00	2014-09-17 16:00	Y				N	4f0yUZ2LYUq8UD6Wpnx1uw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:56		
+%R	89622	106296	4680	Y			10610			144	144	1.44	0	1.44	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-01 08:00	2014-09-15 12:00	2014-09-01 08:00	2014-09-15 12:00	2014-11-17 10:00	2014-12-01 14:00	Y				N	3cFhw+W1FE2ppZQI9PlEHg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:56		
+%R	89623	106296	4680	Y			10603			29	29	0.29	0	0.29	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-01 08:00	2014-09-15 12:00	2014-09-01 08:00	2014-09-15 12:00	2014-11-17 10:00	2014-12-01 14:00	Y				N	Y39J0miL1EyMSkDaHbsXIA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:57		
+%R	89624	106298	4680	Y			10614			50	50	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-21 10:00	2014-08-28 12:00	2014-08-21 10:00	2014-08-28 12:00	2014-10-08 12:00	2014-10-15 14:00	Y				N	q+TC3iSvc0WJPYdRRgFS7A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:57		
+%R	89625	106298	4680	Y			10603			13	13	0.26	0	0.26	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-21 10:00	2014-08-28 12:00	2014-08-21 10:00	2014-08-28 12:00	2014-10-08 12:00	2014-10-15 14:00	Y				N	+9IkpU04MUaOsePedDD/iw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:57		
+%R	89626	106299	4680	Y			10603			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-21 10:00	2014-08-31 16:00	2014-08-21 10:00	2014-08-31 16:00	2014-10-08 12:00	2014-10-19 10:00	Y				N	e8+Hqhyzh0mKnT16+j+TNQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:57		
+%R	89627	106302	4680	Y			10610			110	110	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-01 10:00	2014-10-16 16:00	2014-10-01 10:00	2014-10-16 16:00	2014-12-01 14:00	2014-12-17 12:00	Y				N	W3auDrP2D0CbPnkkfU634Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:58		
+%R	89628	106302	4680	Y			10603			28	28	0.25454545	0	0.25454545	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-01 10:00	2014-10-16 16:00	2014-10-01 10:00	2014-10-16 16:00	2014-12-01 14:00	2014-12-17 12:00	Y				N	fH+J2X4WBEmJU035UIRxxg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:58		
+%R	89629	106304	4680	Y			10614			29	29	0.58	0	0.58	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-08 12:00	2014-10-15 14:00	2014-10-08 12:00	2014-10-15 14:00	2014-11-08 14:00	2014-11-15 16:00	Y				N	IEDHhoA3ZkCoN3f7eO+LVg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:58		
+%R	89630	106304	4680	Y			10603			8	8	0.16	0	0.16	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-08 12:00	2014-10-15 14:00	2014-10-08 12:00	2014-10-15 14:00	2014-11-08 14:00	2014-11-15 16:00	Y				N	dTb/XdkSO0OJXFrr1yQfNA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:58		
+%R	89631	106305	4680	Y			10603			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-08 12:00	2014-10-19 10:00	2014-10-08 12:00	2014-10-19 10:00	2014-11-08 14:00	2014-11-18 12:00	Y				N	oBX7SeX5j02GSwiO1JIEEw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:59		
+%R	89632	106308	4680	Y			10610			131	131	1.45555556	0	1.45555556	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-18 12:00	2014-12-01 14:00	2014-11-18 12:00	2014-12-01 14:00	2014-12-18 14:00	2014-12-31 16:00	Y				N	mYDb1Nz9EE+0YwQRNrUQ+w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:59		
+%R	89633	106308	4680	Y			10603			33	33	0.36666667	0	0.36666667	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-18 12:00	2014-12-01 14:00	2014-11-18 12:00	2014-12-01 14:00	2014-12-18 14:00	2014-12-31 16:00	Y				N	ANSN8QQrcECqwX+JUv5iDw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:59		
+%R	89634	106309	4680	Y			10608			57	57	0.63333333	0	0.63333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-14 08:00	2014-08-27 10:00	2014-08-14 08:00	2014-08-27 10:00	2015-01-14 10:00	2015-01-27 12:00	Y				N	N0kirhVCWUi2umgLoor7vA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:59		
+%R	89635	106309	4680	Y			10603			29	29	0.32222222	0	0.32222222	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-14 08:00	2014-08-27 10:00	2014-08-14 08:00	2014-08-27 10:00	2015-01-14 10:00	2015-01-27 12:00	Y				N	M1xQa6Vhx0miy76U80D96Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 19:59		
+%R	89636	106310	4680	Y			10607			90	90	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-27 10:00	2014-09-09 12:00	2014-08-27 10:00	2014-09-09 12:00	2015-01-27 12:00	2015-02-09 14:00	Y				N	VMiEKxvfwEKrniotczwtdQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:00		
+%R	89637	106310	4680	Y			10603			23	23	0.25555556	0	0.25555556	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-27 10:00	2014-09-09 12:00	2014-08-27 10:00	2014-09-09 12:00	2015-01-27 12:00	2015-02-09 14:00	Y				N	q+5/c0ct5kGgHvprlOw7RQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:00		
+%R	89638	106313	4680	Y			10607			80	80	0.61538462	0	0.61538462	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-02 10:00	2014-09-21 12:00	2014-09-02 10:00	2014-09-21 12:00	2014-12-15 08:00	2015-01-03 10:00	Y				N	uQXgIgyRbUWXDoOGy4MYBw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:00		
+%R	89639	106313	4680	Y			10603			40	40	0.30769231	0	0.30769231	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-02 10:00	2014-09-21 12:00	2014-09-02 10:00	2014-09-21 12:00	2014-12-15 08:00	2015-01-03 10:00	Y				N	HDrGw5wVIkaJtceqpg4t8g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:00		
+%R	89640	106314	4680	Y			10614			30	30	0.375	0	0.375	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-21 12:00	2014-10-02 12:00	2014-09-21 12:00	2014-10-02 12:00	2015-01-03 10:00	2015-01-14 10:00	Y				N	UwSGUDuNOUKQKGhsSQTGUA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:01		
+%R	89641	106314	4680	Y			10603			15	15	0.1875	0	0.1875	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-21 12:00	2014-10-02 12:00	2014-09-21 12:00	2014-10-02 12:00	2015-01-03 10:00	2015-01-14 10:00	Y				N	GsBFOyD1tEKhCjkmqkdVhg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:01		
+%R	89642	106315	4680	Y			10614			17	17	0.18888889	0	0.18888889	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-21 12:00	2014-10-04 14:00	2014-09-21 12:00	2014-10-04 14:00	2015-01-03 10:00	2015-01-15 12:00	Y				N	ARrVAJwZ+EeH6s/LXyXCzg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:01		
+%R	89643	106315	4680	Y			10603			8	8	0.08888889	0	0.08888889	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-21 12:00	2014-10-04 14:00	2014-09-21 12:00	2014-10-04 14:00	2015-01-03 10:00	2015-01-15 12:00	Y				N	5zvGOUNzqESYErz6eTDs0A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:01		
+%R	89644	106316	4680	Y			10607			200	200	0.5	0	0.5	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	Y				N	eNsKvxvqakiWGSvd/+3YgQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:02		
+%R	89645	106316	4680	Y			10603			100	100	0.25	0	0.25	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	2014-11-22 08:00	2015-01-18 16:00	Y				N	nUyiDudJ/k6ry1bdezq3BQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:02		
+%R	89646	106318	4680	Y			10611			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	Y				N	GhTU86544kmutCBt2ye45Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:24		
+%R	89647	106318	4680	Y			10603			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	2014-02-03 08:00	2014-02-12 14:00	Y				N	qRvNhfY66kqRs7WY1xK3Mw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:24		
+%R	89648	106319	4680	Y			10611			7	7	0.23333333	0	0.23333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-20 08:00	2014-02-24 14:00	2014-02-20 08:00	2014-02-24 14:00	2015-01-26 10:00	2015-01-29 16:00	Y				N	21fqPNk/0E6YhfuH4mZIdw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:25		
+%R	89649	106320	4680	Y			10611			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-16 10:00	2014-02-25 16:00	2014-02-16 10:00	2014-02-25 16:00	2014-02-23 12:00	2014-03-05 10:00	Y				N	pxGhJlbslUu9h5CYMJ/v2w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:25		
+%R	89650	106320	4680	Y			10603			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-16 10:00	2014-02-25 16:00	2014-02-16 10:00	2014-02-25 16:00	2014-02-23 12:00	2014-03-05 10:00	Y				N	RYOEI5neMEKGlMDD6xKbeQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:25		
+%R	89651	106321	4680	Y			10611			7	7	0.23333333	0	0.23333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-06 12:00	2014-03-11 10:00	2014-03-06 12:00	2014-03-11 10:00	2015-01-31 08:00	2015-02-03 14:00	Y				N	ebyf8XWTxE668+CJoVFMiA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:25		
+%R	89652	106322	4680	Y			10611			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-11 10:00	2014-03-20 16:00	2014-03-11 10:00	2014-03-20 16:00	2014-03-24 12:00	2014-04-03 10:00	Y				N	D9oU46cbT0iB6CIEPk3EdQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:25		
+%R	89653	106322	4680	Y			10603			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-11 10:00	2014-03-20 16:00	2014-03-11 10:00	2014-03-20 16:00	2014-03-24 12:00	2014-04-03 10:00	Y				N	m0wNtY1+vkiTsDv2y+LWLA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:26		
+%R	89654	106323	4680	Y			10611			7	7	0.23333333	0	0.23333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-05 12:00	2014-04-09 10:00	2014-04-05 12:00	2014-04-09 10:00	2015-02-03 14:00	2015-02-08 12:00	Y				N	m2OUcGuVeE60q89b73iUIQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:26		
+%R	89655	106324	4680	Y			10611			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-03 10:00	2014-04-13 16:00	2014-04-03 10:00	2014-04-13 16:00	2014-04-29 14:00	2014-05-10 12:00	Y				N	kdjb7RHGd0qUHnMC3lrJKg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:26		
+%R	89656	106324	4680	Y			10603			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-03 10:00	2014-04-13 16:00	2014-04-03 10:00	2014-04-13 16:00	2014-04-29 14:00	2014-05-10 12:00	Y				N	rsFmo8xdA0Srj0dHy2spmQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:26		
+%R	89657	106325	4680	Y			10611			7	7	0.23333333	0	0.23333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-28 12:00	2014-05-03 10:00	2014-04-28 12:00	2014-05-03 10:00	2015-02-08 12:00	2015-02-12 10:00	Y				N	VzvZqfqd6UW4PRQSzKVKUA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:26		
+%R	89658	106326	4680	Y			10611			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-28 12:00	2014-05-08 10:00	2014-04-28 12:00	2014-05-08 10:00	2014-06-07 10:00	2014-06-16 16:00	Y				N	DbFVNg/Z3kuefC20RSRMvw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:26		
+%R	89659	106326	4680	Y			10603			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-28 12:00	2014-05-08 10:00	2014-04-28 12:00	2014-05-08 10:00	2014-06-07 10:00	2014-06-16 16:00	Y				N	Rj4fL7evW0iDyQSPd0HR4w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:26		
+%R	89660	106327	4680	Y			10611			7	7	0.23333333	0	0.23333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-25 08:00	2014-05-28 14:00	2014-05-25 08:00	2014-05-28 14:00	2015-02-12 10:00	2015-02-16 16:00	Y				N	UfEcm+TiK0a2Tw2i3+sAgA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:27		
+%R	89661	106328	4680	Y			10611			3	3	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-08 10:00	2014-05-12 16:00	2014-05-08 10:00	2014-05-12 16:00	2014-07-16 08:00	2014-07-20 14:00	Y				N	c8LqGMxCdEaV2ftpJSUfHA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:27		
+%R	89662	106328	4680	Y			10603			1	1	0.03333333	0	0.03333333	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-08 10:00	2014-05-12 16:00	2014-05-08 10:00	2014-05-12 16:00	2014-07-16 08:00	2014-07-20 14:00	Y				N	WRimDl09QE6nMO5JW1vaiQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:27		
+%R	89663	106329	4680	Y			10611			2	2	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-28 14:00	2014-06-01 10:00	2014-05-28 14:00	2014-06-01 10:00	2015-02-17 08:00	2015-02-19 12:00	Y				N	D4rntkPE8E6Jdyy4VRUbvA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:27		
+%R	89664	106330	4680	Y			10612			100	100	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-02-23 12:00	2014-03-09 16:00	2014-02-23 12:00	2014-03-09 16:00	2014-05-05 14:00	2014-05-20 10:00	Y				N	KpMgLZ+eQ06dNzOG+5vgbQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:28		
+%R	89665	106330	4680	Y			10603			100	100	1	0	1	0	0	0		0.00	10.00	0.00	0.00	10.00			2014-02-23 12:00	2014-03-09 16:00	2014-02-23 12:00	2014-03-09 16:00	2014-05-05 14:00	2014-05-20 10:00	Y				N	ZvDVQVTTrUSTy85i+Q1hSQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:28		
+%R	89666	106331	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-06-01 10:00	2014-06-08 12:00	Y				N	/LpD1kgULUugKHijqCx0YQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:28		
+%R	89667	106331	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-05 10:00	2014-03-12 12:00	2014-03-05 10:00	2014-03-12 12:00	2014-06-01 10:00	2014-06-08 12:00	Y				N	U+kVHF1nuESw/PRaIQ1DAQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:28		
+%R	89668	106332	4680	Y			10611			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-08 12:00	2014-06-18 10:00	2014-06-08 12:00	2014-06-18 10:00	2014-11-08 14:00	2014-11-18 12:00	Y				N	+QACH9vVWE2nm5oEX7/+Fg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:28		
+%R	89669	106332	4680	Y			10603			3.5	3.5	0.05	0	0.05	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-08 12:00	2014-06-18 10:00	2014-06-08 12:00	2014-06-18 10:00	2014-11-08 14:00	2014-11-18 12:00	Y				N	Ewex06RVRUCBJgli0IND3A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:28		
+%R	89670	106333	4680	Y			10612			20	20	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-16 08:00	2014-03-30 12:00	2014-03-16 08:00	2014-03-30 12:00	2014-05-20 10:00	2014-06-03 14:00	Y				N	WQhzcp7QwkGDZRecjGVvNw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:30		
+%R	89671	106333	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-03-16 08:00	2014-03-30 12:00	2014-03-16 08:00	2014-03-30 12:00	2014-05-20 10:00	2014-06-03 14:00	Y				N	oY3CdSROvkGI38Div3ZEXQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:30		
+%R	89672	106334	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-03 10:00	2014-04-10 12:00	2014-04-03 10:00	2014-04-10 12:00	2014-06-08 12:00	2014-06-15 14:00	Y				N	Re8tbgbTp0m/Hd2/KVu9Tg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:30		
+%R	89673	106334	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-03 10:00	2014-04-10 12:00	2014-04-03 10:00	2014-04-10 12:00	2014-06-08 12:00	2014-06-15 14:00	Y				N	RyQaWDe5cUicqO1o5gt3sA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:30		
+%R	89674	106335	4680	Y			10612			100	100	1	0	1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-30 12:00	2014-08-13 16:00	2014-07-30 12:00	2014-08-13 16:00	2014-11-18 12:00	2014-12-02 16:00	Y				N	WwGIXwmcU0O1UnpLLoiWvA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:30		
+%R	89675	106335	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-30 12:00	2014-08-13 16:00	2014-07-30 12:00	2014-08-13 16:00	2014-11-18 12:00	2014-12-02 16:00	Y				N	eRwYPcfMdk22QqAxyah4DQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:30		
+%R	89676	106336	4680	Y			10612			20	20	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-05 12:00	2014-04-19 16:00	2014-04-05 12:00	2014-04-19 16:00	2014-06-03 14:00	2014-06-18 10:00	Y				N	ytBFXcDbzE2ai/3SgRHt9A	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:31		
+%R	89677	106336	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-05 12:00	2014-04-19 16:00	2014-04-05 12:00	2014-04-19 16:00	2014-06-03 14:00	2014-06-18 10:00	Y				N	wr5f6+47L0OQA5XQtCCy1w	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:31		
+%R	89678	106337	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-10 12:00	2014-05-17 14:00	2014-05-10 12:00	2014-05-17 14:00	2014-06-26 14:00	2014-07-03 16:00	Y				N	gdYvNU5MFkevrCKpdzGxEQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:31		
+%R	89679	106337	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-10 12:00	2014-05-17 14:00	2014-05-10 12:00	2014-05-17 14:00	2014-06-26 14:00	2014-07-03 16:00	Y				N	vdXysUhr5UC5vQ1DG82NVg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:31		
+%R	89680	106338	4680	Y			10612			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-15 12:00	2014-09-29 16:00	2014-09-15 12:00	2014-09-29 16:00	2014-12-03 08:00	2014-12-17 12:00	Y				N	RN69VwtvUUm6QIJqXjgbOA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:32		
+%R	89681	106338	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-09-15 12:00	2014-09-29 16:00	2014-09-15 12:00	2014-09-29 16:00	2014-12-03 08:00	2014-12-17 12:00	Y				N	aE/sb3T3/ky258o+oFg6ig	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:32		
+%R	89682	106339	4680	Y			10612			20	20	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-26 08:00	2014-05-10 12:00	2014-04-26 08:00	2014-05-10 12:00	2014-06-18 10:00	2014-07-02 14:00	Y				N	CWR1vOab9UyN/dJGvFGJuA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:32		
+%R	89683	106339	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-04-26 08:00	2014-05-10 12:00	2014-04-26 08:00	2014-05-10 12:00	2014-06-18 10:00	2014-07-02 14:00	Y				N	fDXFKWpaE0Sq2wt+wYzFxQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:32		
+%R	89684	106340	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-17 08:00	2014-06-24 10:00	2014-06-17 08:00	2014-06-24 10:00	2014-07-29 10:00	2014-08-05 12:00	Y				N	zcTyRxort0eqHQ4cSRIwHA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89685	106340	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-17 08:00	2014-06-24 10:00	2014-06-17 08:00	2014-06-24 10:00	2014-07-29 10:00	2014-08-05 12:00	Y				N	M2qMsesOQkqSAJqSG04poQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89686	106341	4680	Y			10612			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-18 08:00	2014-11-01 12:00	2014-10-18 08:00	2014-11-01 12:00	2014-12-17 12:00	2014-12-31 16:00	Y				N	x58Cz+pdYUySlQ7ETP9chQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89687	106341	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-10-18 08:00	2014-11-01 12:00	2014-10-18 08:00	2014-11-01 12:00	2014-12-17 12:00	2014-12-31 16:00	Y				N	NIEQgfw4ukyiGEI5rzD1sw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89688	106342	4680	Y			10612			20	20	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-19 08:00	2014-06-02 12:00	2014-05-19 08:00	2014-06-02 12:00	2014-07-02 14:00	2014-07-17 10:00	Y				N	Z74uqpCxPEGzVXT8K90ZFQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89689	106342	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-05-19 08:00	2014-06-02 12:00	2014-05-19 08:00	2014-06-02 12:00	2014-07-02 14:00	2014-07-17 10:00	Y				N	0AnJH81jDk+r0dJisW4kUQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89690	106343	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-20 14:00	2014-07-27 16:00	2014-07-20 14:00	2014-07-27 16:00	2014-08-20 08:00	2014-08-27 10:00	Y				N	Jjbb/FlsSUyI6ce9zVvTzw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89691	106343	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-20 14:00	2014-07-27 16:00	2014-07-20 14:00	2014-07-27 16:00	2014-08-20 08:00	2014-08-27 10:00	Y				N	shOszJqO6Eqh27Ogr3Ry/Q	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89692	106344	4680	Y			10612			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-12-01 14:00	2014-12-16 10:00	2014-12-01 14:00	2014-12-16 10:00	2015-01-01 08:00	2015-01-15 12:00	Y				N	oNxBt+Nj4kCNqL1bbtQmlw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:33		
+%R	89693	106344	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-12-01 14:00	2014-12-16 10:00	2014-12-01 14:00	2014-12-16 10:00	2015-01-01 08:00	2015-01-15 12:00	Y				N	X1BCI5uoP0mVJXUCEOKZ8g	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:34		
+%R	89694	106345	4680	Y			10612			20	20	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-02 12:00	2014-06-16 16:00	2014-06-02 12:00	2014-06-16 16:00	2014-07-17 10:00	2014-07-31 14:00	Y				N	/528Hv3QH0+IaR4oXDWUEQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:34		
+%R	89695	106345	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-02 12:00	2014-06-16 16:00	2014-06-02 12:00	2014-06-16 16:00	2014-07-17 10:00	2014-07-31 14:00	Y				N	dNUYyYwHr06htx5Uh3zxhA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:34		
+%R	89696	106346	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-31 14:00	2014-08-07 16:00	2014-07-31 14:00	2014-08-07 16:00	2014-09-13 08:00	2014-09-20 10:00	Y				N	U6rWxMKkCkSSQC1Brt6UxQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:34		
+%R	89697	106346	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-31 14:00	2014-08-07 16:00	2014-07-31 14:00	2014-08-07 16:00	2014-09-13 08:00	2014-09-20 10:00	Y				N	CeforIx+K0ChHoINYaFdGw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:34		
+%R	89698	106347	4680	Y			10612			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-12-16 10:00	2014-12-25 16:00	2014-12-16 10:00	2014-12-25 16:00	2015-01-15 12:00	2015-01-26 10:00	Y				N	KTwVh2P8Mki5j0eomtV+zg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:34		
+%R	89699	106347	4680	Y			10603			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-12-16 10:00	2014-12-25 16:00	2014-12-16 10:00	2014-12-25 16:00	2015-01-15 12:00	2015-01-26 10:00	Y				N	jzvHQOdgXkiV+NbuxICvzg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:34		
+%R	89700	106348	4680	Y			10612			20	20	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-17 08:00	2014-07-01 12:00	2014-06-17 08:00	2014-07-01 12:00	2014-07-31 14:00	2014-08-16 10:00	Y				N	UiJOpuKgPkqP3GZw4CLWXw	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:35		
+%R	89701	106348	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-06-17 08:00	2014-07-01 12:00	2014-06-17 08:00	2014-07-01 12:00	2014-07-31 14:00	2014-08-16 10:00	Y				N	UbIlYWYYuE2EczdcAyv8Ag	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:35		
+%R	89702	106349	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-26 08:00	2014-09-02 10:00	2014-08-26 08:00	2014-09-02 10:00	2014-11-06 12:00	2014-11-13 14:00	Y				N	JTydVwxUZEWPY7NImqn4tg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:35		
+%R	89703	106349	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-08-26 08:00	2014-09-02 10:00	2014-08-26 08:00	2014-09-02 10:00	2014-11-06 12:00	2014-11-13 14:00	Y				N	mjNh0ZUrp0mU7erzlZKjoQ	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:35		
+%R	89704	106350	4680	Y			10603			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	Y				N	4bH2YoqY2Eaiy8V3i3iAsA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:35		
+%R	89705	106350	4680	Y			10612			10	10	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	2015-01-26 10:00	2015-02-09 14:00	Y				N	QAGHApzxb0yVPXvqJKXvIg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:35		
+%R	89706	106351	4680	Y			10612			14	14	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-01 12:00	2014-07-12 10:00	2014-07-01 12:00	2014-07-12 10:00	2014-08-16 10:00	2014-08-25 16:00	Y				N	34REyD6xq06nTZaIbUjPng	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:38		
+%R	89708	106351	4680	Y			10603			7	7	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-07-01 12:00	2014-07-12 10:00	2014-07-01 12:00	2014-07-12 10:00	2014-08-16 10:00	2014-08-25 16:00	Y				N	4zMXuYhaq0KLZoQ7fLcGgg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:38		
+%R	89709	106352	4680	Y			10612			10	10	0.2	0	0.2	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	Y				N	Qo0MSLNFcUyR7NJwW7yobg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:38		
+%R	89710	106352	4680	Y			10603			5	5	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	2014-11-13 14:00	2014-11-20 16:00	Y				N	SscjVjDBLEikQO7FJPqBZg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:38		
+%R	89711	106353	4680	Y			10612			4	4	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-22 08:00	2014-11-26 16:00	2014-11-22 08:00	2014-11-26 16:00	2015-02-03 14:00	2015-02-09 14:00	Y				N	UJRaGVerAk2jwOhjSoolVg	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:38		
+%R	89712	106353	4680	Y			10603			4	4	0.1	0	0.1	0	0	0		0.00	0.00	0.00	0.00	0.00			2014-11-22 08:00	2014-11-26 16:00	2014-11-22 08:00	2014-11-26 16:00	2015-02-03 14:00	2015-02-09 14:00	Y				N	Lc8GP32BYUCuK1yD1zGYyA	COST_PER_QTY	0.00	0		RT_Labor	ST_Rsrc	admin	2013-09-06 20:38		
+%T	TASKACTV
+%F	task_id	actv_code_type_id	actv_code_id	proj_id
+%R	106071	1734	7490	4680
+%R	106071	1735	7491	4680
+%R	106071	1736	7489	4680
+%R	106071	1737	7505	4680
+%R	106222	1734	7490	4680
+%R	106222	1735	7491	4680
+%R	106222	1736	7489	4680
+%R	106222	1737	7505	4680
+%R	106223	1734	7490	4680
+%R	106223	1735	7491	4680
+%R	106223	1736	7489	4680
+%R	106223	1737	7505	4680
+%R	106224	1734	7490	4680
+%R	106224	1735	7491	4680
+%R	106224	1736	7498	4680
+%R	106224	1737	7505	4680
+%R	106225	1734	7490	4680
+%R	106225	1735	7491	4680
+%R	106225	1736	7498	4680
+%R	106225	1737	7505	4680
+%R	106226	1734	7490	4680
+%R	106226	1735	7491	4680
+%R	106226	1736	7498	4680
+%R	106226	1737	7505	4680
+%R	106227	1734	7490	4680
+%R	106227	1735	7491	4680
+%R	106227	1736	7498	4680
+%R	106227	1737	7505	4680
+%R	106228	1734	7490	4680
+%R	106228	1735	7491	4680
+%R	106228	1736	7502	4680
+%R	106228	1737	7505	4680
+%R	106229	1734	7490	4680
+%R	106229	1735	7491	4680
+%R	106229	1736	7502	4680
+%R	106229	1737	7505	4680
+%R	106230	1734	7490	4680
+%R	106230	1735	7491	4680
+%R	106230	1736	7514	4680
+%R	106230	1737	7505	4680
+%R	106231	1734	7490	4680
+%R	106231	1735	7492	4680
+%R	106231	1736	7498	4680
+%R	106231	1737	7506	4680
+%R	106232	1734	7490	4680
+%R	106232	1735	7492	4680
+%R	106232	1736	7498	4680
+%R	106232	1737	7506	4680
+%R	106233	1734	7490	4680
+%R	106233	1735	7492	4680
+%R	106233	1736	7498	4680
+%R	106233	1737	7507	4680
+%R	106234	1734	7490	4680
+%R	106234	1735	7492	4680
+%R	106234	1736	7498	4680
+%R	106234	1737	7507	4680
+%R	106235	1734	7490	4680
+%R	106235	1735	7492	4680
+%R	106235	1736	7498	4680
+%R	106235	1737	7508	4680
+%R	106236	1734	7490	4680
+%R	106236	1735	7492	4680
+%R	106236	1736	7498	4680
+%R	106236	1737	7508	4680
+%R	106237	1734	7490	4680
+%R	106237	1735	7492	4680
+%R	106237	1736	7498	4680
+%R	106237	1737	7509	4680
+%R	106238	1734	7490	4680
+%R	106238	1735	7492	4680
+%R	106238	1736	7498	4680
+%R	106238	1737	7509	4680
+%R	106239	1734	7490	4680
+%R	106239	1735	7492	4680
+%R	106239	1736	7498	4680
+%R	106239	1737	7510	4680
+%R	106240	1734	7490	4680
+%R	106240	1735	7492	4680
+%R	106240	1736	7498	4680
+%R	106240	1737	7510	4680
+%R	106241	1734	7490	4680
+%R	106241	1735	7492	4680
+%R	106241	1736	7498	4680
+%R	106241	1737	7511	4680
+%R	106242	1734	7490	4680
+%R	106242	1735	7492	4680
+%R	106242	1736	7498	4680
+%R	106242	1737	7511	4680
+%R	106243	1734	7490	4680
+%R	106243	1735	7493	4680
+%R	106243	1736	7514	4680
+%R	106243	1737	7506	4680
+%R	106244	1734	7490	4680
+%R	106244	1735	7493	4680
+%R	106244	1736	7499	4680
+%R	106244	1737	7506	4680
+%R	106245	1734	7490	4680
+%R	106245	1735	7493	4680
+%R	106245	1736	7499	4680
+%R	106245	1737	7506	4680
+%R	106246	1734	7490	4680
+%R	106246	1735	7493	4680
+%R	106246	1736	7499	4680
+%R	106246	1737	7506	4680
+%R	106247	1734	7490	4680
+%R	106247	1735	7493	4680
+%R	106247	1736	7499	4680
+%R	106247	1737	7506	4680
+%R	106248	1734	7490	4680
+%R	106248	1735	7493	4680
+%R	106248	1736	7514	4680
+%R	106248	1737	7507	4680
+%R	106249	1734	7490	4680
+%R	106249	1735	7493	4680
+%R	106249	1736	7499	4680
+%R	106249	1737	7507	4680
+%R	106250	1734	7490	4680
+%R	106250	1735	7493	4680
+%R	106250	1736	7499	4680
+%R	106250	1737	7507	4680
+%R	106251	1734	7490	4680
+%R	106251	1735	7493	4680
+%R	106251	1736	7499	4680
+%R	106251	1737	7507	4680
+%R	106252	1734	7490	4680
+%R	106252	1735	7493	4680
+%R	106252	1736	7499	4680
+%R	106252	1737	7507	4680
+%R	106253	1734	7490	4680
+%R	106253	1735	7493	4680
+%R	106253	1736	7499	4680
+%R	106253	1737	7507	4680
+%R	106254	1734	7490	4680
+%R	106254	1735	7493	4680
+%R	106254	1736	7514	4680
+%R	106254	1737	7508	4680
+%R	106255	1734	7490	4680
+%R	106255	1735	7493	4680
+%R	106255	1736	7499	4680
+%R	106255	1737	7508	4680
+%R	106256	1734	7490	4680
+%R	106256	1735	7493	4680
+%R	106256	1736	7499	4680
+%R	106256	1737	7508	4680
+%R	106257	1734	7490	4680
+%R	106257	1735	7493	4680
+%R	106257	1736	7499	4680
+%R	106257	1737	7508	4680
+%R	106258	1734	7490	4680
+%R	106258	1735	7493	4680
+%R	106258	1736	7499	4680
+%R	106258	1737	7508	4680
+%R	106259	1734	7490	4680
+%R	106259	1735	7493	4680
+%R	106259	1736	7499	4680
+%R	106259	1737	7508	4680
+%R	106260	1734	7490	4680
+%R	106260	1735	7493	4680
+%R	106260	1736	7514	4680
+%R	106260	1737	7509	4680
+%R	106261	1734	7490	4680
+%R	106261	1735	7493	4680
+%R	106261	1736	7499	4680
+%R	106261	1737	7509	4680
+%R	106262	1734	7490	4680
+%R	106262	1735	7493	4680
+%R	106262	1736	7499	4680
+%R	106262	1737	7509	4680
+%R	106263	1734	7490	4680
+%R	106263	1735	7493	4680
+%R	106263	1736	7499	4680
+%R	106263	1737	7509	4680
+%R	106264	1734	7490	4680
+%R	106264	1735	7493	4680
+%R	106264	1736	7499	4680
+%R	106264	1737	7509	4680
+%R	106265	1734	7490	4680
+%R	106265	1735	7493	4680
+%R	106265	1736	7499	4680
+%R	106265	1737	7509	4680
+%R	106266	1734	7490	4680
+%R	106266	1735	7493	4680
+%R	106266	1736	7514	4680
+%R	106266	1737	7510	4680
+%R	106267	1734	7490	4680
+%R	106267	1735	7493	4680
+%R	106267	1736	7499	4680
+%R	106267	1737	7510	4680
+%R	106268	1734	7490	4680
+%R	106268	1735	7493	4680
+%R	106268	1736	7499	4680
+%R	106268	1737	7510	4680
+%R	106269	1734	7490	4680
+%R	106269	1735	7493	4680
+%R	106269	1736	7499	4680
+%R	106269	1737	7510	4680
+%R	106270	1734	7490	4680
+%R	106270	1735	7493	4680
+%R	106270	1736	7499	4680
+%R	106270	1737	7510	4680
+%R	106271	1734	7490	4680
+%R	106271	1735	7493	4680
+%R	106271	1736	7499	4680
+%R	106271	1737	7510	4680
+%R	106272	1734	7490	4680
+%R	106272	1735	7493	4680
+%R	106272	1736	7514	4680
+%R	106272	1737	7511	4680
+%R	106273	1734	7490	4680
+%R	106273	1735	7493	4680
+%R	106273	1736	7499	4680
+%R	106273	1737	7511	4680
+%R	106274	1734	7490	4680
+%R	106274	1735	7493	4680
+%R	106274	1736	7499	4680
+%R	106274	1737	7511	4680
+%R	106275	1734	7490	4680
+%R	106275	1735	7493	4680
+%R	106275	1736	7499	4680
+%R	106275	1737	7511	4680
+%R	106276	1734	7490	4680
+%R	106276	1735	7493	4680
+%R	106276	1736	7502	4680
+%R	106276	1737	7511	4680
+%R	106277	1734	7490	4680
+%R	106277	1735	7493	4680
+%R	106277	1736	7502	4680
+%R	106277	1737	7511	4680
+%R	106278	1734	7490	4680
+%R	106278	1735	7493	4680
+%R	106278	1736	7498	4680
+%R	106278	1737	7511	4680
+%R	106279	1734	7490	4680
+%R	106279	1735	7493	4680
+%R	106279	1736	7499	4680
+%R	106279	1737	7512	4680
+%R	106280	1734	7490	4680
+%R	106280	1735	7493	4680
+%R	106280	1736	7499	4680
+%R	106280	1737	7513	4680
+%R	106281	1734	7490	4680
+%R	106281	1735	7493	4680
+%R	106281	1736	7499	4680
+%R	106281	1737	7513	4680
+%R	106282	1734	7490	4680
+%R	106282	1735	7493	4680
+%R	106282	1736	7499	4680
+%R	106282	1737	7513	4680
+%R	106283	1734	7490	4680
+%R	106283	1735	7494	4680
+%R	106283	1736	7499	4680
+%R	106283	1737	7506	4680
+%R	106284	1734	7490	4680
+%R	106284	1735	7494	4680
+%R	106284	1736	7499	4680
+%R	106284	1737	7506	4680
+%R	106285	1734	7490	4680
+%R	106285	1735	7494	4680
+%R	106285	1736	7499	4680
+%R	106285	1737	7507	4680
+%R	106286	1734	7490	4680
+%R	106286	1735	7494	4680
+%R	106286	1736	7499	4680
+%R	106286	1737	7507	4680
+%R	106287	1734	7490	4680
+%R	106287	1735	7494	4680
+%R	106287	1736	7499	4680
+%R	106287	1737	7507	4680
+%R	106288	1734	7490	4680
+%R	106288	1735	7494	4680
+%R	106288	1736	7499	4680
+%R	106288	1737	7507	4680
+%R	106289	1734	7490	4680
+%R	106289	1735	7494	4680
+%R	106289	1736	7499	4680
+%R	106289	1737	7507	4680
+%R	106290	1734	7490	4680
+%R	106290	1735	7494	4680
+%R	106290	1736	7499	4680
+%R	106290	1737	7507	4680
+%R	106291	1734	7490	4680
+%R	106291	1735	7494	4680
+%R	106291	1736	7499	4680
+%R	106291	1737	7508	4680
+%R	106292	1734	7490	4680
+%R	106292	1735	7494	4680
+%R	106292	1736	7499	4680
+%R	106292	1737	7508	4680
+%R	106293	1734	7490	4680
+%R	106293	1735	7494	4680
+%R	106293	1736	7499	4680
+%R	106293	1737	7508	4680
+%R	106294	1734	7490	4680
+%R	106294	1735	7494	4680
+%R	106294	1736	7499	4680
+%R	106294	1737	7508	4680
+%R	106295	1734	7490	4680
+%R	106295	1735	7494	4680
+%R	106295	1736	7499	4680
+%R	106295	1737	7508	4680
+%R	106296	1734	7490	4680
+%R	106296	1735	7494	4680
+%R	106296	1736	7499	4680
+%R	106296	1737	7508	4680
+%R	106297	1734	7490	4680
+%R	106297	1735	7494	4680
+%R	106297	1736	7499	4680
+%R	106297	1737	7509	4680
+%R	106298	1734	7490	4680
+%R	106298	1735	7494	4680
+%R	106298	1736	7499	4680
+%R	106298	1737	7509	4680
+%R	106299	1734	7490	4680
+%R	106299	1735	7494	4680
+%R	106299	1736	7499	4680
+%R	106299	1737	7509	4680
+%R	106300	1734	7490	4680
+%R	106300	1735	7494	4680
+%R	106300	1736	7499	4680
+%R	106300	1737	7509	4680
+%R	106301	1734	7490	4680
+%R	106301	1735	7494	4680
+%R	106301	1736	7499	4680
+%R	106301	1737	7509	4680
+%R	106302	1734	7490	4680
+%R	106302	1735	7494	4680
+%R	106302	1736	7499	4680
+%R	106302	1737	7509	4680
+%R	106303	1734	7490	4680
+%R	106303	1735	7494	4680
+%R	106303	1736	7499	4680
+%R	106303	1737	7510	4680
+%R	106304	1734	7490	4680
+%R	106304	1735	7494	4680
+%R	106304	1736	7499	4680
+%R	106304	1737	7510	4680
+%R	106305	1734	7490	4680
+%R	106305	1735	7494	4680
+%R	106305	1736	7499	4680
+%R	106305	1737	7510	4680
+%R	106306	1734	7490	4680
+%R	106306	1735	7494	4680
+%R	106306	1736	7499	4680
+%R	106306	1737	7510	4680
+%R	106307	1734	7490	4680
+%R	106307	1735	7494	4680
+%R	106307	1736	7499	4680
+%R	106307	1737	7510	4680
+%R	106308	1734	7490	4680
+%R	106308	1735	7494	4680
+%R	106308	1736	7499	4680
+%R	106308	1737	7510	4680
+%R	106309	1734	7490	4680
+%R	106309	1735	7494	4680
+%R	106309	1736	7499	4680
+%R	106309	1737	7511	4680
+%R	106310	1734	7490	4680
+%R	106310	1735	7494	4680
+%R	106310	1736	7499	4680
+%R	106310	1737	7511	4680
+%R	106311	1734	7490	4680
+%R	106311	1735	7494	4680
+%R	106311	1736	7499	4680
+%R	106311	1737	7511	4680
+%R	106312	1734	7490	4680
+%R	106312	1735	7494	4680
+%R	106312	1736	7499	4680
+%R	106312	1737	7512	4680
+%R	106313	1734	7490	4680
+%R	106313	1735	7494	4680
+%R	106313	1736	7499	4680
+%R	106313	1737	7512	4680
+%R	106314	1734	7490	4680
+%R	106314	1735	7494	4680
+%R	106314	1736	7499	4680
+%R	106314	1737	7512	4680
+%R	106315	1734	7490	4680
+%R	106315	1735	7494	4680
+%R	106315	1736	7499	4680
+%R	106315	1737	7512	4680
+%R	106316	1734	7490	4680
+%R	106316	1735	7494	4680
+%R	106316	1736	7499	4680
+%R	106316	1737	7513	4680
+%R	106317	1734	7490	4680
+%R	106317	1735	7494	4680
+%R	106317	1736	7499	4680
+%R	106317	1737	7513	4680
+%R	106318	1734	7490	4680
+%R	106318	1735	7495	4680
+%R	106318	1736	7500	4680
+%R	106318	1737	7506	4680
+%R	106319	1734	7490	4680
+%R	106319	1735	7495	4680
+%R	106319	1736	7500	4680
+%R	106319	1737	7506	4680
+%R	106320	1734	7490	4680
+%R	106320	1735	7495	4680
+%R	106320	1736	7500	4680
+%R	106320	1737	7507	4680
+%R	106321	1734	7490	4680
+%R	106321	1735	7495	4680
+%R	106321	1736	7500	4680
+%R	106321	1737	7507	4680
+%R	106322	1734	7490	4680
+%R	106322	1735	7495	4680
+%R	106322	1736	7500	4680
+%R	106322	1737	7508	4680
+%R	106323	1734	7490	4680
+%R	106323	1735	7495	4680
+%R	106323	1736	7500	4680
+%R	106323	1737	7508	4680
+%R	106324	1734	7490	4680
+%R	106324	1735	7495	4680
+%R	106324	1736	7500	4680
+%R	106324	1737	7509	4680
+%R	106325	1734	7490	4680
+%R	106325	1735	7495	4680
+%R	106325	1736	7500	4680
+%R	106325	1737	7509	4680
+%R	106326	1734	7490	4680
+%R	106326	1735	7495	4680
+%R	106326	1736	7500	4680
+%R	106326	1737	7510	4680
+%R	106327	1734	7490	4680
+%R	106327	1735	7495	4680
+%R	106327	1736	7500	4680
+%R	106327	1737	7510	4680
+%R	106328	1734	7490	4680
+%R	106328	1735	7495	4680
+%R	106328	1736	7500	4680
+%R	106328	1737	7511	4680
+%R	106329	1734	7490	4680
+%R	106329	1735	7495	4680
+%R	106329	1736	7500	4680
+%R	106329	1737	7511	4680
+%R	106330	1734	7490	4680
+%R	106330	1735	7496	4680
+%R	106330	1736	7501	4680
+%R	106330	1737	7506	4680
+%R	106331	1734	7490	4680
+%R	106331	1735	7496	4680
+%R	106331	1736	7501	4680
+%R	106331	1737	7506	4680
+%R	106332	1734	7490	4680
+%R	106332	1735	7496	4680
+%R	106332	1736	7501	4680
+%R	106332	1737	7506	4680
+%R	106333	1734	7490	4680
+%R	106333	1735	7496	4680
+%R	106333	1736	7501	4680
+%R	106333	1737	7507	4680
+%R	106334	1734	7490	4680
+%R	106334	1735	7496	4680
+%R	106334	1736	7501	4680
+%R	106334	1737	7507	4680
+%R	106335	1734	7490	4680
+%R	106335	1735	7496	4680
+%R	106335	1736	7501	4680
+%R	106335	1737	7507	4680
+%R	106336	1734	7490	4680
+%R	106336	1735	7496	4680
+%R	106336	1736	7501	4680
+%R	106336	1737	7508	4680
+%R	106337	1734	7490	4680
+%R	106337	1735	7496	4680
+%R	106337	1736	7501	4680
+%R	106337	1737	7508	4680
+%R	106338	1734	7490	4680
+%R	106338	1735	7496	4680
+%R	106338	1736	7501	4680
+%R	106338	1737	7508	4680
+%R	106339	1734	7490	4680
+%R	106339	1735	7496	4680
+%R	106339	1736	7501	4680
+%R	106339	1737	7509	4680
+%R	106340	1734	7490	4680
+%R	106340	1735	7496	4680
+%R	106340	1736	7501	4680
+%R	106340	1737	7509	4680
+%R	106341	1734	7490	4680
+%R	106341	1735	7496	4680
+%R	106341	1736	7501	4680
+%R	106341	1737	7509	4680
+%R	106342	1734	7490	4680
+%R	106342	1735	7496	4680
+%R	106342	1736	7501	4680
+%R	106342	1737	7510	4680
+%R	106343	1734	7490	4680
+%R	106343	1735	7496	4680
+%R	106343	1736	7501	4680
+%R	106343	1737	7510	4680
+%R	106344	1734	7490	4680
+%R	106344	1735	7496	4680
+%R	106344	1736	7501	4680
+%R	106344	1737	7510	4680
+%R	106345	1734	7490	4680
+%R	106345	1735	7496	4680
+%R	106345	1736	7501	4680
+%R	106345	1737	7511	4680
+%R	106346	1734	7490	4680
+%R	106346	1735	7496	4680
+%R	106346	1736	7501	4680
+%R	106346	1737	7511	4680
+%R	106347	1734	7490	4680
+%R	106347	1735	7496	4680
+%R	106347	1736	7501	4680
+%R	106347	1737	7511	4680
+%R	106348	1734	7490	4680
+%R	106348	1735	7496	4680
+%R	106348	1736	7501	4680
+%R	106348	1737	7512	4680
+%R	106349	1734	7490	4680
+%R	106349	1735	7496	4680
+%R	106349	1736	7501	4680
+%R	106349	1737	7512	4680
+%R	106350	1734	7490	4680
+%R	106350	1735	7496	4680
+%R	106350	1736	7501	4680
+%R	106350	1737	7512	4680
+%R	106351	1734	7490	4680
+%R	106351	1735	7496	4680
+%R	106351	1736	7501	4680
+%R	106351	1737	7513	4680
+%R	106352	1734	7490	4680
+%R	106352	1735	7496	4680
+%R	106352	1736	7501	4680
+%R	106352	1737	7513	4680
+%R	106353	1734	7490	4680
+%R	106353	1735	7496	4680
+%R	106353	1736	7501	4680
+%R	106353	1737	7513	4680
+%R	106354	1734	7490	4680
+%R	106354	1735	7497	4680
+%R	106354	1736	7503	4680
+%R	106354	1737	7515	4680
+%R	106355	1734	7490	4680
+%R	106355	1735	7494	4680
+%R	106355	1736	7499	4680
+%R	106355	1737	7515	4680
+%R	106356	1734	7490	4680
+%R	106356	1735	7495	4680
+%R	106356	1736	7500	4680
+%R	106356	1737	7515	4680
+%R	106357	1734	7490	4680
+%R	106357	1735	7496	4680
+%R	106357	1736	7501	4680
+%R	106357	1737	7515	4680
+%R	106358	1734	7490	4680
+%R	106358	1735	7497	4680
+%R	106358	1736	7503	4680
+%R	106358	1737	7515	4680
+%R	106559	1734	7490	4680
+%R	106559	1735	7516	4680
+%R	106559	1736	7518	4680
+%R	106559	1737	7515	4680
+%R	106560	1734	7490	4680
+%R	106560	1735	7517	4680
+%R	106560	1736	7519	4680
+%R	106560	1737	7505	4680
+%R	106561	1734	7490	4680
+%R	106561	1735	7517	4680
+%R	106561	1736	7519	4680
+%R	106561	1737	7505	4680
+%R	106564	1734	7490	4680
+%R	106564	1735	7517	4680
+%R	106564	1736	7519	4680
+%R	106564	1737	7506	4680
+%R	106565	1734	7490	4680
+%R	106565	1735	7517	4680
+%R	106565	1736	7519	4680
+%R	106565	1737	7506	4680
+%R	106566	1734	7490	4680
+%R	106566	1735	7517	4680
+%R	106566	1736	7519	4680
+%R	106566	1737	7507	4680
+%R	106567	1734	7490	4680
+%R	106567	1735	7517	4680
+%R	106567	1736	7519	4680
+%R	106567	1737	7507	4680
+%R	106568	1734	7490	4680
+%R	106568	1735	7517	4680
+%R	106568	1736	7519	4680
+%R	106568	1737	7508	4680
+%R	106569	1734	7490	4680
+%R	106569	1735	7517	4680
+%R	106569	1736	7519	4680
+%R	106569	1737	7508	4680
+%R	106570	1734	7490	4680
+%R	106570	1735	7517	4680
+%R	106570	1736	7519	4680
+%R	106570	1737	7509	4680
+%R	106571	1734	7490	4680
+%R	106571	1735	7517	4680
+%R	106571	1736	7519	4680
+%R	106571	1737	7509	4680
+%R	106572	1734	7490	4680
+%R	106572	1735	7517	4680
+%R	106572	1736	7519	4680
+%R	106572	1737	7510	4680
+%R	106573	1734	7490	4680
+%R	106573	1735	7517	4680
+%R	106573	1736	7519	4680
+%R	106573	1737	7510	4680
+%R	106574	1734	7490	4680
+%R	106574	1735	7517	4680
+%R	106574	1736	7519	4680
+%R	106574	1737	7511	4680
+%R	106575	1734	7490	4680
+%R	106575	1735	7517	4680
+%R	106575	1736	7519	4680
+%R	106575	1737	7511	4680
+%R	106576	1734	7490	4680
+%R	106576	1735	7517	4680
+%R	106576	1736	7521	4680
+%R	106576	1737	7515	4680
+%R	106577	1734	7490	4680
+%R	106577	1735	7517	4680
+%R	106577	1736	7521	4680
+%R	106577	1737	7515	4680
+%R	106578	1734	7490	4680
+%R	106578	1735	7517	4680
+%R	106578	1736	7521	4680
+%R	106578	1737	7515	4680
+%R	106579	1734	7490	4680
+%R	106579	1735	7517	4680
+%R	106579	1736	7521	4680
+%R	106579	1737	7515	4680
+%R	106580	1734	7490	4680
+%R	106580	1735	7517	4680
+%R	106580	1736	7522	4680
+%R	106580	1737	7515	4680
+%R	106581	1734	7490	4680
+%R	106581	1735	7517	4680
+%R	106581	1736	7522	4680
+%R	106581	1737	7515	4680
+%R	106582	1734	7490	4680
+%R	106582	1735	7517	4680
+%R	106582	1736	7522	4680
+%R	106582	1737	7515	4680
+%R	106583	1734	7490	4680
+%R	106583	1735	7517	4680
+%R	106583	1736	7522	4680
+%R	106583	1737	7515	4680
+%R	106584	1734	7490	4680
+%R	106584	1735	7517	4680
+%R	106584	1736	7522	4680
+%R	106584	1737	7515	4680
+%R	106585	1734	7490	4680
+%R	106585	1735	7517	4680
+%R	106585	1736	7522	4680
+%R	106585	1737	7515	4680
+%R	106586	1734	7490	4680
+%R	106586	1735	7517	4680
+%R	106586	1736	7522	4680
+%R	106586	1737	7515	4680
+%R	106587	1734	7490	4680
+%R	106587	1735	7517	4680
+%R	106587	1736	7522	4680
+%R	106587	1737	7515	4680
+%R	106588	1734	7490	4680
+%R	106588	1735	7517	4680
+%R	106588	1736	7522	4680
+%R	106588	1737	7515	4680
+%R	106589	1734	7490	4680
+%R	106589	1735	7517	4680
+%R	106589	1736	7522	4680
+%R	106589	1737	7515	4680
+%R	106590	1734	7490	4680
+%R	106590	1735	7517	4680
+%R	106590	1736	7522	4680
+%R	106590	1737	7515	4680
+%R	106591	1734	7490	4680
+%R	106591	1735	7517	4680
+%R	106591	1736	7522	4680
+%R	106591	1737	7515	4680
+%R	106592	1734	7490	4680
+%R	106592	1735	7517	4680
+%R	106592	1736	7518	4680
+%R	106592	1737	7515	4680
+%R	106767	1734	7490	4680
+%R	106767	1735	7517	4680
+%R	106767	1736	7519	4680
+%R	106767	1737	7506	4680
+%R	106768	1734	7490	4680
+%R	106768	1735	7517	4680
+%R	106768	1736	7519	4680
+%R	106768	1737	7506	4680
+%R	106769	1734	7490	4680
+%R	106769	1735	7517	4680
+%R	106769	1736	7519	4680
+%R	106769	1737	7507	4680
+%R	106770	1734	7490	4680
+%R	106770	1735	7517	4680
+%R	106770	1736	7519	4680
+%R	106770	1737	7507	4680
+%R	106771	1734	7490	4680
+%R	106771	1735	7517	4680
+%R	106771	1736	7519	4680
+%R	106771	1737	7508	4680
+%R	106772	1734	7490	4680
+%R	106772	1735	7517	4680
+%R	106772	1736	7519	4680
+%R	106772	1737	7508	4680
+%R	106773	1734	7490	4680
+%R	106773	1735	7517	4680
+%R	106773	1736	7519	4680
+%R	106773	1737	7509	4680
+%R	106774	1734	7490	4680
+%R	106774	1735	7517	4680
+%R	106774	1736	7519	4680
+%R	106774	1737	7509	4680
+%R	106775	1734	7490	4680
+%R	106775	1735	7517	4680
+%R	106775	1736	7519	4680
+%R	106775	1737	7510	4680
+%R	106776	1734	7490	4680
+%R	106776	1735	7517	4680
+%R	106776	1736	7519	4680
+%R	106776	1737	7510	4680
+%R	106777	1734	7490	4680
+%R	106777	1735	7517	4680
+%R	106777	1736	7519	4680
+%R	106777	1737	7511	4680
+%R	106778	1734	7490	4680
+%R	106778	1735	7517	4680
+%R	106778	1736	7519	4680
+%R	106778	1737	7511	4680
+%R	106779	1734	7490	4680
+%R	106779	1735	7517	4680
+%R	106779	1736	7520	4680
+%R	106779	1737	7506	4680
+%R	106780	1734	7490	4680
+%R	106780	1735	7517	4680
+%R	106780	1736	7520	4680
+%R	106780	1737	7506	4680
+%R	106781	1734	7490	4680
+%R	106781	1735	7517	4680
+%R	106781	1736	7520	4680
+%R	106781	1737	7507	4680
+%R	106782	1734	7490	4680
+%R	106782	1735	7517	4680
+%R	106782	1736	7520	4680
+%R	106782	1737	7507	4680
+%R	106783	1734	7490	4680
+%R	106783	1735	7517	4680
+%R	106783	1736	7520	4680
+%R	106783	1737	7508	4680
+%R	106784	1734	7490	4680
+%R	106784	1735	7517	4680
+%R	106784	1736	7520	4680
+%R	106784	1737	7508	4680
+%R	106785	1734	7490	4680
+%R	106785	1735	7517	4680
+%R	106785	1736	7520	4680
+%R	106785	1737	7509	4680
+%R	106786	1734	7490	4680
+%R	106786	1735	7517	4680
+%R	106786	1736	7520	4680
+%R	106786	1737	7509	4680
+%R	106787	1734	7490	4680
+%R	106787	1735	7517	4680
+%R	106787	1736	7520	4680
+%R	106787	1737	7510	4680
+%R	106788	1734	7490	4680
+%R	106788	1735	7517	4680
+%R	106788	1736	7520	4680
+%R	106788	1737	7510	4680
+%R	106789	1734	7490	4680
+%R	106789	1735	7517	4680
+%R	106789	1736	7520	4680
+%R	106789	1737	7511	4680
+%R	106790	1734	7490	4680
+%R	106790	1735	7517	4680
+%R	106790	1736	7520	4680
+%R	106790	1737	7511	4680
+%R	106791	1734	7490	4680
+%R	106791	1735	7517	4680
+%R	106791	1736	7521	4680
+%R	106791	1737	7515	4680
+%R	106792	1734	7490	4680
+%R	106792	1735	7517	4680
+%R	106792	1736	7521	4680
+%R	106792	1737	7515	4680
+%R	106793	1734	7490	4680
+%R	106793	1735	7517	4680
+%R	106793	1736	7521	4680
+%R	106793	1737	7515	4680
+%R	106794	1734	7490	4680
+%R	106794	1735	7517	4680
+%R	106794	1736	7521	4680
+%R	106794	1737	7515	4680
+%E


### PR DESCRIPTION
When using the stoi, stof or stod to convert string to number, there were errors if string is empty.
So, I did add a check to confirm that the string has value before parsing it.